### PR TITLE
feat: Get rid of environment name in edge lambdas

### DIFF
--- a/edge-lambdas/dist/viewer-request/index.js
+++ b/edge-lambdas/dist/viewer-request/index.js
@@ -175,11 +175,8 @@ function getTreeHash(host, config, s3) {
     return __awaiter(this, void 0, void 0, function* () {
         // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
         // Preview name is either a sanitized branch name or it follows the preview-[treeHash] pattern
-        // We only run preview deploys in staging
         let previewName;
-        if (config.environment === 'staging' &&
-            config.previewDeploymentPostfix &&
-            host.includes(config.previewDeploymentPostfix)) {
+        if (config.previewDeploymentPostfix && host.includes(config.previewDeploymentPostfix)) {
             previewName = host.split('.')[0];
             // If the request is for a specific tree hash preview deployment, we use that hash
             const previewHash = getPreviewHash(previewName);

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -149,7 +149,7 @@ const addCacheHeader = (response) => {
  */
 const addRobotsHeader = (response, config) => {
     let headers = response.headers;
-    if (config.environment === 'staging') {
+    if (config.blockRobots === 'true') {
         headers = setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow');
     }
     return Object.assign(Object.assign({}, response), { headers });

--- a/edge-lambdas/src/config.ts
+++ b/edge-lambdas/src/config.ts
@@ -11,10 +11,10 @@ export function getConfig(): Config {
 }
 
 export type Config = {
-    environment: 'staging' | 'production'
     originBucketName: string
     originBucketRegion: string
     previewDeploymentPostfix?: string
     defaultBranchName?: string
     blockIframes?: string
+    blockRobots?: string
 }

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -69,14 +69,9 @@ async function getUri(request: CloudFrontRequest, config: Config, s3: S3) {
 async function getTreeHash(host: string, config: Config, s3: S3) {
     // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
     // Preview name is either a sanitized branch name or it follows the preview-[treeHash] pattern
-    // We only run preview deploys in staging
     let previewName
 
-    if (
-        config.environment === 'staging' &&
-        config.previewDeploymentPostfix &&
-        host.includes(config.previewDeploymentPostfix)
-    ) {
+    if (config.previewDeploymentPostfix && host.includes(config.previewDeploymentPostfix)) {
         previewName = host.split('.')[0]
 
         // If the request is for a specific tree hash preview deployment, we use that hash

--- a/edge-lambdas/src/viewer-response/viewer-response.test.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.test.ts
@@ -4,7 +4,6 @@ import {getHandler} from './viewer-response'
 describe(`Viewer response Lambda@Edge`, () => {
     test(`Adds security and cache control custom headers to a response object for prod`, async () => {
         const handler = getHandler({
-            environment: 'production',
             originBucketName: 'test-cursor-bucket-prod',
             originBucketRegion: 'eu-west-1'
         })
@@ -21,12 +20,12 @@ describe(`Viewer response Lambda@Edge`, () => {
         })
     })
 
-    test(`Adds robots custom headers to a response object in staging`, async () => {
+    test(`Adds robots custom headers to a response object if configured`, async () => {
         const handler = getHandler({
-            environment: 'staging',
             originBucketName: 'test-origin-bucket-staging',
             originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.staging.example.com'
+            previewDeploymentPostfix: '.app.staging.example.com',
+            blockRobots: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.staging.example.com'})
@@ -45,7 +44,6 @@ describe(`Viewer response Lambda@Edge`, () => {
 
     test(`Adds security with frame blocking custom header to a response if configured`, async () => {
         const handler = getHandler({
-            environment: 'production',
             originBucketName: 'test-origin-bucket',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.example.com',

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -65,7 +65,7 @@ export const addCacheHeader = (response: CloudFrontResponse) => {
 export const addRobotsHeader = (response: CloudFrontResponse, config: Config) => {
     let headers = response.headers
 
-    if (config.environment === 'staging') {
+    if (config.blockRobots === 'true') {
         headers = setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow')
     }
 

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -47,12 +47,11 @@ Note that there are two AWS providers, since we need to access two AWS regions
 - the S3 bucket for origin lives in the default region
 
 <!-- BEGIN_TF_DOCS -->
-
 #### Requirements
 
-| Name                                                   | Version  |
-| ------------------------------------------------------ | -------- |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 3.8.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.8.0 |
 
 #### Providers
 
@@ -60,14 +59,14 @@ No providers.
 
 #### Modules
 
-| Name                                                                 | Source                             | Version |
-| -------------------------------------------------------------------- | ---------------------------------- | ------- |
-| <a name="module_cdn"></a> [cdn](#module_cdn)                         | ./modules/frontend-spa-cdn         | n/a     |
-| <a name="module_certificate"></a> [certificate](#module_certificate) | ./modules/frontend-spa-certificate | n/a     |
-| <a name="module_dns"></a> [dns](#module_dns)                         | ./modules/frontend-spa-dns         | n/a     |
-| <a name="module_lambda_role"></a> [lambda_role](#module_lambda_role) | ./modules/frontend-spa-lambda-role | n/a     |
-| <a name="module_lambdas"></a> [lambdas](#module_lambdas)             | ./modules/frontend-spa-edge-lambda | n/a     |
-| <a name="module_s3"></a> [s3](#module_s3)                            | ./modules/frontend-spa-s3          | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | ./modules/frontend-spa-cdn | n/a |
+| <a name="module_certificate"></a> [certificate](#module\_certificate) | ./modules/frontend-spa-certificate | n/a |
+| <a name="module_dns"></a> [dns](#module\_dns) | ./modules/frontend-spa-dns | n/a |
+| <a name="module_lambda_role"></a> [lambda\_role](#module\_lambda\_role) | ./modules/frontend-spa-lambda-role | n/a |
+| <a name="module_lambdas"></a> [lambdas](#module\_lambdas) | ./modules/frontend-spa-edge-lambda | n/a |
+| <a name="module_s3"></a> [s3](#module\_s3) | ./modules/frontend-spa-s3 | n/a |
 
 #### Resources
 
@@ -75,20 +74,19 @@ No resources.
 
 #### Inputs
 
-| Name                                                                                                      | Description                                                                                                   | Type     | Default    | Required |
-| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- | ---------- | :------: |
-| <a name="input_app_name"></a> [app_name](#input_app_name)                                                 | Name of the app (kebab-case)                                                                                  | `string` | n/a        |   yes    |
-| <a name="input_block_iframes"></a> [block_iframes](#input_block_iframes)                                  | Should add custom header blocking access via iframes?                                                         | `bool`   | `true`     |    no    |
-| <a name="input_bucket_prefix"></a> [bucket_prefix](#input_bucket_prefix)                                  | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a        |   yes    |
-| <a name="input_default_repo_branch_name"></a> [default_repo_branch_name](#input_default_repo_branch_name) | Name of the default branch of the project repo                                                                | `string` | `"master"` |    no    |
-| <a name="input_env"></a> [env](#input_env)                                                                | Environment (production/staging)                                                                              | `string` | n/a        |   yes    |
-| <a name="input_subdomain"></a> [subdomain](#input_subdomain)                                              | Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com)                            | `string` | n/a        |   yes    |
-| <a name="input_zone_domain"></a> [zone_domain](#input_zone_domain)                                        | The domain where the app lives (e.g. 'example.com' if the app lives at hello.example.com)                     | `string` | n/a        |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
+| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
+| <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
+| <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
+| <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com) | `string` | n/a | yes |
+| <a name="input_zone_domain"></a> [zone\_domain](#input\_zone\_domain) | The domain where the app lives (e.g. 'example.com' if the app lives at hello.example.com) | `string` | n/a | yes |
 
 #### Outputs
 
-| Name                                                                                                                          | Description |
-| ----------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| <a name="output_bucket_deployer_iam_policy_arn"></a> [bucket_deployer_iam_policy_arn](#output_bucket_deployer_iam_policy_arn) | n/a         |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_deployer_iam_policy_arn"></a> [bucket\_deployer\_iam\_policy\_arn](#output\_bucket\_deployer\_iam\_policy\_arn) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudfront_distribution" "this" {
   price_class         = var.cloudfront_price_class
   comment             = "${var.app_name} - ${var.domain_name}"
 
-  aliases = lower(var.env) == "production" ? [var.domain_name] : [var.domain_name, "*.${var.domain_name}"]
+  # aliases = lower(var.env) == "production" ? [var.domain_name] : [var.domain_name, "*.${var.domain_name}"]
 
   # The distribution is served by the origin S3 bucket accessible only via OAI
   origin {

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudfront_distribution" "this" {
   price_class         = var.cloudfront_price_class
   comment             = "${var.app_name} - ${var.domain_name}"
 
-  # aliases = lower(var.env) == "production" ? [var.domain_name] : [var.domain_name, "*.${var.domain_name}"]
+  aliases = lower(var.env) == "production" ? [var.domain_name] : [var.domain_name, "*.${var.domain_name}"]
 
   # The distribution is served by the origin S3 bucket accessible only via OAI
   origin {

--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -8,11 +8,11 @@ resource "local_file" "lambda_source" {
 
 resource "local_file" "lambda_config" {
   content = jsonencode({
-    "environment"              = var.env
     "originBucketName"         = var.bucket_name
     "originBucketRegion"       = var.bucket_region
     "previewDeploymentPostfix" = var.env == "staging" ? ".${var.domain_name}" : ""
     "blockIframes"             = var.block_iframes == true ? "true" : "false"
+    "blockRobots"              = var.env == "staging" ? "true" : "false"
     "defaultBranchName"        = var.default_repo_branch_name
   })
   filename = "${path.root}/dist/${var.app_name}/${var.event_type}/config.json"


### PR DESCRIPTION
Instead of relying on the environment name (i.e. checking if the env is "staging") we can use other config options:
- only serve preview deployments if `previewDeploymentPostfix` is specified - i.e. don't pass this option in production
- only block robots with the response header if `blockRobots` option is passed to the lambda. 
We still decide if we should pass these options in Terraform based on the environment, but at least the lambda code doesn't need to know anything about environments.