### PR TITLE
feat: Translation add-on

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @pleo-io/frontend-ops

--- a/edge-lambdas/.gitattributes
+++ b/edge-lambdas/.gitattributes
@@ -1,0 +1,1 @@
+dist/** linguist-generated

--- a/edge-lambdas/.gitignore
+++ b/edge-lambdas/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn-error.log
+coverage

--- a/edge-lambdas/README.md
+++ b/edge-lambdas/README.md
@@ -36,6 +36,7 @@ process. Allowed configuration options:
 | previewDeploymentPostfix | The base part of the app url, e.g. `app.staging.pleo.io`. Only applicable in staging.                                             | `string`             | n/a      |   yes    |
 | defaultBranchName        | The name of the default branch of the repo that deploys the app                                                                   | `string`             | `master` |    no    |
 | blockIframes             | Should the `X-Frame-Options` custom header be added to block rendering of the app in iframes?                                     | `bool`               | `false`  |    no    |
+| isLocalised             | Should fetch translation hash and add cookie & preload header for translation files?                                     | `bool`               | `false`  |    no    |
 
 ### Details
 

--- a/edge-lambdas/README.md
+++ b/edge-lambdas/README.md
@@ -62,8 +62,8 @@ behavior which they are associated with.
         (`my-branch`) version of the app, and a request to
         `preview-{version}.app.staging.example.com` is a request for a specific version.
 
-    2. Based on the above, fetch the cursor file (containing the current active tree hash) from the
-       S3 origin bucket to figure out which HTML file to request from CDN. The cursor file is
+    2. Based on the above, fetch the cursor file (containing the current active app version) from
+       the S3 origin bucket to figure out which HTML file to request from CDN. The cursor file is
        updated as part of the [CD pipeline](https://github.com/pleo-oss/pleo-spa-cicd).
 
         For example, for the main branch requested we would fetch `deploys/main` file from S3, and
@@ -79,8 +79,8 @@ behavior which they are associated with.
         > discussion of this topic please see
         > [AWS's guide to using external data in Edge Lambda](https://aws.amazon.com/blogs/networking-and-content-delivery/leveraging-external-data-in-lambdaedge).
 
-    3. Once the tree hash is established, the request object is modified to fetch the right version
-       of the file from the origin bucket.
+    3. Once the app version is established, the request object is modified to fetch the right
+       version of the file from the origin bucket.
 
         For example, we might modify the request to fetch
         `/html/ce4a66492551f1cd2fad5296ee94b8ea2667eac3/index.html` following the example above.

--- a/edge-lambdas/README.md
+++ b/edge-lambdas/README.md
@@ -36,7 +36,7 @@ process. Allowed configuration options:
 | previewDeploymentPostfix | The base part of the app url, e.g. `app.staging.pleo.io`. Only applicable in staging.                                             | `string`             | n/a      |   yes    |
 | defaultBranchName        | The name of the default branch of the repo that deploys the app                                                                   | `string`             | `master` |    no    |
 | blockIframes             | Should the `X-Frame-Options` custom header be added to block rendering of the app in iframes?                                     | `bool`               | `false`  |    no    |
-| isLocalised             | Should fetch translation hash and add cookie & preload header for translation files?                                     | `bool`               | `false`  |    no    |
+| isLocalised              | Should fetch translation hash and add cookie & preload header for translation files?                                              | `bool`               | `false`  |    no    |
 
 ### Details
 
@@ -107,6 +107,14 @@ exposing some information under a consistent URL across all websites (e.g.
 `.well-known/apple-app-site-association`). These are handled in a special way by this module, and
 should work as expected if placed in the `.well-known` directory (and not in `/static`) when
 uploaded to S3.
+
+#### Translations
+
+Support for separately served translations can be achieved using the `isLocalised` config option.
+When enabled, the viewer request lambda will fetch the latest version of the translations from S3
+(from a cursor file assumed present at `translation-deploy/latest` key in the origin bucket), and
+pass it to the viewer response lambda which exposes it via a cookie on the response. For more
+details see the `addons/translations.ts` file.
 
 ### Usage
 

--- a/edge-lambdas/dist/viewer-request/index.js
+++ b/edge-lambdas/dist/viewer-request/index.js
@@ -225,7 +225,7 @@ const setTranslationVersionCookie = (response, translationVersion) => {
  * Adds preload header for translation file to speed up rendering of the app. It's crucial to fetch the
  * translations file as soon as possible, since we can't render anything without the translated messages.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
  *
  * The file we ask the browser to pre-fetch is our best guess based on:
  * - the language query param sometimes set on redirects to the app - this takes precedence
@@ -260,7 +260,7 @@ const getTranslationVersion = (s3, config) => translations_awaiter(void 0, void 
         return response;
     }
     catch (error) {
-        console.error(error);
+        console.error('getTranslationVersion failed', error);
         // We never want this function to throw to avoid the app failing on any issues with the translations
         // deployments. We return an empty translation version here, which means the app will fall back to the
         // default language (which uses the app version instead of the translations version)

--- a/edge-lambdas/dist/viewer-request/index.js
+++ b/edge-lambdas/dist/viewer-request/index.js
@@ -80,6 +80,15 @@ function getConfig() {
 ;// CONCATENATED MODULE: external "path"
 const external_path_namespaceObject = require("path");
 ;// CONCATENATED MODULE: ./src/utils.ts
+var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 /**
  * Appends a custom header to a passed CloudFront header map
  * @param headers - CloudFront headers map
@@ -88,7 +97,7 @@ const external_path_namespaceObject = require("path");
  * @param options.merge - Should the current header value be merged with the new one (e.g. for cookies)
  * @returns A new, modified CloudFront header maps
  */
-function setHeader(headers, headerName, headerValue, options = {}) {
+function utils_setHeader(headers, headerName, headerValue, options = {}) {
     var _a;
     const headerKey = headerName.toLowerCase();
     const previousHeader = options.merge ? (_a = headers[headerKey]) !== null && _a !== void 0 ? _a : [] : [];
@@ -100,19 +109,17 @@ function setHeader(headers, headerName, headerValue, options = {}) {
  * @param headerName - Header name to retrieve
  * @returns The first found value of the specified header, if available
  */
-function getHeader(request, headerName) {
+function utils_getHeader(request, headerName) {
     var _a, _b, _c;
     return (_c = (_b = (_a = request.headers) === null || _a === void 0 ? void 0 : _a[headerName.toLowerCase()]) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.value;
 }
-const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor';
-const TREE_HASH_HEADER = 'X-Tree-Hash';
 /**
  * Extract the value of a specific cookie from CloudFront headers map, if present
  * @param headers - CloudFront headers map
  * @param cookieName - The key of the cookie to extract the value for
  * @returns The string value of the cookie if present, otherwise null
  */
-function getCookie(headers, cookieName) {
+function utils_getCookie(headers, cookieName) {
     const cookieHeader = headers.cookie;
     if (!cookieHeader) {
         return null;
@@ -128,9 +135,141 @@ function getCookie(headers, cookieName) {
     }
     return null;
 }
+/**
+ * Fetches a file from the S3 origin bucket and returns its content
+ * @param key key for the S3 bucket
+ * @param bucket name of the S3 bucket
+ * @param s3 S3 instance
+ * @returns content of the file
+ */
+function fetchFileFromS3Bucket(key, bucket, s3) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield s3.getObject({ Bucket: bucket, Key: key }).promise();
+        if (!response.Body) {
+            throw new Error(`Empty response from S3 for ${key} in ${bucket} bucket`);
+        }
+        return response.Body.toString('utf-8').trim();
+    });
+}
+
+;// CONCATENATED MODULE: ./src/addons/translations.ts
+var translations_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+const TRANSLATION_VERSION_HEADER = 'X-Translation-Version';
+const APP_VERSION_HEADER = 'X-App-Version';
+const DEFAULT_LANGUAGE = 'en';
+const LANG_QUERY_PARAM = 'lang';
+const LANG_COOKIE_NAME = 'x-pleo-language';
+const TRANSLATION_VERSION_COOKIE_NAME = 'translation-version';
+/**
+ * This addon adds the translations functionality to the SPA served. It uses a secondary cursor deployment.
+ * The latest version of translations is fetched when the HTML requested by the browser (at the same time as
+ * the latest version of the app is served). Then that version is returned together with the HTML response
+ * via a cookie header.
+ * Additionally, to improve performance, a preload link header is added to the HTML response to trigger fetching
+ * of the message catalog as soon as possible, without having to wait for the app JS to be downloaded, parsed
+ * and executed before making a request for the message catalog.
+ */
+/**
+ * Modifies the response object to enrich it with headers used to serve translations for the app.
+ */
+function addTranslationInfoToResponse(response, request, config) {
+    if (config.isLocalised !== 'true') {
+        return response;
+    }
+    const translationVersion = getHeader(request, TRANSLATION_VERSION_HEADER);
+    const appVersion = getHeader(request, APP_VERSION_HEADER);
+    let modifiedResponse = setTranslationVersionCookie(response, translationVersion);
+    if (Boolean(translationVersion)) {
+        modifiedResponse = addPreloadHeader({
+            response: modifiedResponse,
+            request,
+            translationVersion,
+            appVersion
+        });
+    }
+    return modifiedResponse;
+}
+/**
+ * Modifies the pass request object to add the app and translation version on the request
+ * object as custom headers. This allows the viewer-response lambda to pick up this information
+ * and use it enrich the response.
+ */
+function addTranslationInfoToRequest({ request, translationVersion, appVersion, config }) {
+    if (!config.isLocalised) {
+        return;
+    }
+    if (translationVersion) {
+        request.headers = utils_setHeader(request.headers, TRANSLATION_VERSION_HEADER, translationVersion);
+    }
+    request.headers = utils_setHeader(request.headers, APP_VERSION_HEADER, appVersion);
+}
+/**
+ * Adds a cookie with the current translation version. This value is used by the app to request
+ * the translation catalog (for any language other than the default language)
+ */
+const setTranslationVersionCookie = (response, translationVersion) => {
+    let headers = response.headers;
+    headers = setHeader(headers, 'Set-Cookie', `${TRANSLATION_VERSION_COOKIE_NAME}=${translationVersion}`);
+    return Object.assign(Object.assign({}, response), { headers });
+};
+/**
+ * Adds preload header for translation file to speed up rendering of the app. It's crucial to fetch the
+ * translations file as soon as possible, since we can't render anything without the translated messages.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+ *
+ * The file we ask the browser to pre-fetch is our best guess based on:
+ * - the language query param sometimes set on redirects to the app - this takes precedence
+ * - the language stored in a cookie, which we set whenever the user selects a language in the app
+ * - falling back to the default language when none of the above is set
+ *
+ * Note that this guess is not guaranteed to be the file that the app will actually request to fetch.
+ * In that case, we will have pre-fetched the wrong file and a second translation file will need to be
+ * fetched. The app will still work, alas slower.
+ */
+const addPreloadHeader = ({ response, request, translationVersion, appVersion }) => {
+    var _a, _b;
+    let headers = response.headers;
+    const urlParams = new URLSearchParams(request.querystring);
+    const language = (_b = (_a = urlParams.get(LANG_QUERY_PARAM)) !== null && _a !== void 0 ? _a : getCookie(request.headers, LANG_COOKIE_NAME)) !== null && _b !== void 0 ? _b : DEFAULT_LANGUAGE;
+    // If the language guessed is the default language, instead of using the translation version,
+    // we use the version of the app. The default language is deployed together with the app, and not
+    // separately, so it follows the app versioning and the translations versioning.
+    const hash = language === DEFAULT_LANGUAGE ? appVersion : translationVersion;
+    headers = setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`);
+    return Object.assign(Object.assign({}, response), { headers });
+};
+/**
+ * Get the latest translation cursor file from S3 bucket
+ */
+const getTranslationVersion = (s3, config) => translations_awaiter(void 0, void 0, void 0, function* () {
+    try {
+        if (!config.isLocalised) {
+            return;
+        }
+        const response = yield fetchFileFromS3Bucket('translation-deploy/latest', config.originBucketName, s3);
+        return response;
+    }
+    catch (error) {
+        console.error(error);
+        // We never want this function to throw to avoid the app failing on any issues with the translations
+        // deployments. We return an empty translation version here, which means the app will fall back to the
+        // default language (which uses the app version instead of the translations version)
+        return undefined;
+    }
+});
 
 ;// CONCATENATED MODULE: ./src/viewer-request/viewer-request.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+var viewer_request_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -141,40 +280,47 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 };
 
 
+
 const DEFAULT_BRANCH_DEFAULT_NAME = 'master';
 /**
- * Edge Lambda handler triggered on "viewer-request" event, on the default CF behavior of the web app CF distribution.
- * The default CF behaviour only handles requests for HTML documents and requests for static files (e.g. /, /bills, /settings/accounting etc.)
- * Since our app is client side routed, all these requests return the same HTML index file.
+ * Edge Lambda handler triggered on "viewer-request" event, on the default CF behavior of the web app
+ * CF distribution. The default CF behavior only handles requests for HTML documents and requests for
+ * static files (e.g. /, /bills, /settings/accounting etc.). Since our app is client side routed, all
+ * these requests return the same HTML index file.
  *
- * This lambda runs for every request and modifies the request object before it's used to fetch the resource from the origin (S3 bucket).
- * It calculates which HTML file the request should respond with based on the host name specified by the request, and sets that file as the URI of the request.
+ * This lambda runs for every request and modifies the request object before it's used to fetch the
+ * resource from the origin (S3 bucket). It calculates which HTML file the request should respond with
+ * based on the host name specified by the request, and sets that file as the URI of the request.
  * The options are:
- * - HTML for latest tree hash on the main branch - e.g. app.staging.example.com and app.example.com
- * - HTML for latest tree hash on a feature branch (branch preview deployment) - e.g. my-branch.staging.example.com
- * - HTML for a specific tree hash (hash preview deployment) - e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
+ * - HTML for latest app version on the main branch
+ *   e.g. app.staging.example.com and app.example.com
+ * - HTML for latest app version on a feature branch (branch preview deployment)
+ *   e.g. my-branch.staging.example.com
+ * - HTML for a specific app version (hash preview deployment)
+ *   e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
+ *
+ * If the translations are enabled via configuration, this lambda will also fetch the current translation
+ * version from S3 and pass it to the response lambda via custom headers on the request object.
  */
 function getHandler(config, s3) {
-    const handler = (event) => __awaiter(this, void 0, void 0, function* () {
+    const handler = (event) => viewer_request_awaiter(this, void 0, void 0, function* () {
         const request = event.Records[0].cf.request;
         try {
-            // Get tree hash and translation cursor in parralel to avoid the double network penalty
-            const [treeHash, translationCursor] = yield Promise.all([
-                getTreeHash(request, config, s3),
-                config.isLocalised === 'true'
-                    ? fetchDeploymentTranslationHash(s3, config)
-                    : undefined
-            ].filter((val) => Boolean(val)));
-            const uri = getUri(request, treeHash);
-            // We instruct the CDN to return a file that corresponds to the tree hash requested
+            // Get app version and translation version in parallel to avoid the double network penalty.
+            // Translation hash is only fetched if translations are enabled. Fetching translation cursor
+            // can never throw here, as in case of a failure we're returning a default value.
+            const [appVersion, translationVersion] = yield Promise.all([
+                getAppVersion(request, config, s3),
+                getTranslationVersion(s3, config)
+            ]);
+            // If needed, pass the versions to the viewer response lambda via custom headers on the request
+            addTranslationInfoToRequest({ request, translationVersion, appVersion, config });
+            // We instruct the CDN to return a file that corresponds to the app version calculated
+            const uri = getUri(request, appVersion);
             request.uri = uri;
-            if (config.isLocalised === 'true') {
-                request.headers = setHeader(request.headers, TRANSLATION_CURSOR_HEADER, translationCursor);
-                request.headers = setHeader(request.headers, TREE_HASH_HEADER, treeHash);
-            }
         }
-        catch (e) {
-            console.error(e);
+        catch (error) {
+            console.error(error);
             // On failure, we're requesting a non-existent file on purpose, to allow CF to serve
             // the configured custom error page
             request.uri = '/404';
@@ -183,7 +329,9 @@ function getHandler(config, s3) {
     });
     return handler;
 }
-// We respond with a requested file, but prefix it with the hash of the current active deployment
+/**
+ * We respond with a requested file, but prefix it with the hash of the current active deployment
+ */
 function getUri(request, treeHash) {
     // If the
     // - request uri is for a specific file (e.g. "/iframe.html")
@@ -196,86 +344,58 @@ function getUri(request, treeHash) {
     const filePath = isFileRequest || isWellKnownRequest ? request.uri : '/index.html';
     return external_path_namespaceObject.join('/html', treeHash, filePath);
 }
-// We use repository tree hash to identify the version of the HTML served.
-// It can be either a specific tree hash requested via preview link with a hash, or the latest
-// tree hash for a branch requested (preview or main), which we fetch from cursor files stored in S3
-function getTreeHash(request, config, s3) {
+/**
+ * Calculate the version of the app that should be served.
+ * It can be either a specific version requested via preview link with a hash, or the latest
+ * version for a branch requested (preview or main), which we fetch from cursor files stored in S3
+ */
+function getAppVersion(request, config, s3) {
     var _a;
-    return __awaiter(this, void 0, void 0, function* () {
-        const host = getHeader(request, 'host');
+    return viewer_request_awaiter(this, void 0, void 0, function* () {
+        const host = utils_getHeader(request, 'host');
         if (!host) {
             throw new Error('Missing Host header');
         }
         // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
-        // Preview name is either a sanitized branch name or it follows the preview-[treeHash] pattern
+        // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
         let previewName;
         if (config.previewDeploymentPostfix && host.includes(config.previewDeploymentPostfix)) {
             previewName = host.split('.')[0];
-            // If the request is for a specific tree hash preview deployment, we use that hash
+            // If the request is for a specific hash of a preview deployment, we use that hash
             const previewHash = getPreviewHash(previewName);
             if (previewHash) {
                 return previewHash;
             }
         }
         const defaultBranchName = (_a = config.defaultBranchName) !== null && _a !== void 0 ? _a : DEFAULT_BRANCH_DEFAULT_NAME;
-        // Otherwise we fetch the current tree hash for requested branch from S3
+        // Otherwise we fetch the current app version for requested branch from S3
         const branchName = previewName || defaultBranchName;
-        return fetchDeploymentTreeHash(branchName, config, s3);
+        return fetchAppVersion(branchName, config, s3);
     });
 }
-// We serve a preview for each repo tree hash at e.g.preview-[treeHash].app.staging.example.com
-// If the preview name matches that pattern, we assume it's a tree hash preview
+/**
+ * We serve a preview for each app version at e.g.preview-[hash].app.staging.example.com
+ * If the preview name matches that pattern, we assume it's a hash preview link
+ */
 function getPreviewHash(previewName) {
     var _a;
     const matchHash = /^preview-(?<hash>[a-z0-9]{40})$/.exec(previewName || '');
     return (_a = matchHash === null || matchHash === void 0 ? void 0 : matchHash.groups) === null || _a === void 0 ? void 0 : _a.hash;
 }
 /**
- * Fetches a file from the S3 origin bucket and returns its content
- * @param key key for the S3 bucket
- * @param onEmpty function will be called if file doesn't exist
- * @param config config object
- * @param s3 S3 instance
- * @returns content of the file
+ * Fetch a cursor deploy file from the S3 bucket and returns its content, which is the current
+ * active app version for that branch).
  */
-function fetchFileFromOriginBucket(key, config, s3) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const s3Params = {
-            Bucket: config.originBucketName,
-            Key: key
-        };
-        const response = yield s3.getObject(s3Params).promise();
-        if (!response.Body) {
-            throw new Error();
-        }
-        return response.Body.toString('utf-8').trim();
-    });
-}
-/**
- * Fetches a cursor deploy file from the S3 bucket and returns its content (i.e. the current active tree hash
- * for that branch).
- */
-function fetchDeploymentTreeHash(branch, config, s3) {
-    return __awaiter(this, void 0, void 0, function* () {
+function fetchAppVersion(branch, config, s3) {
+    return viewer_request_awaiter(this, void 0, void 0, function* () {
         try {
-            const response = yield fetchFileFromOriginBucket(`deploys/${branch}`, config, s3);
-            return response;
+            return yield fetchFileFromS3Bucket(`deploys/${branch}`, config.originBucketName, s3);
         }
-        catch (_a) {
+        catch (error) {
             throw new Error(`Cursor file not found for branch=${branch}`);
         }
     });
 }
-// Get the latest translation cursor file from S3 bucket
-const fetchDeploymentTranslationHash = (s3, config) => __awaiter(void 0, void 0, void 0, function* () {
-    try {
-        const response = yield fetchFileFromOriginBucket(`translation-deploy/latest`, config, s3);
-        return response;
-    }
-    catch (_a) {
-        throw new Error(`Latest translation cursor file not found`);
-    }
-});
 
 ;// CONCATENATED MODULE: ./src/viewer-request/index.ts
 

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -120,7 +120,7 @@ function getHandler(config) {
         response = addSecurityHeaders(response, config);
         response = addCacheHeader(response);
         response = addRobotsHeader(response, config);
-        response = addCookieHeader(response, translationCursor);
+        response = setTranslationHashCookie(response, translationCursor);
         if (translationCursor !== DEFAULT_TRANSLATION_CURSOR) {
             response = addPreloadHeader(response, request, translationCursor, treeHash);
         }
@@ -169,7 +169,7 @@ const addRobotsHeader = (response, config) => {
 /**
  * Adds cookie 'translation-hash' with value of latest translation cursor
  */
-const addCookieHeader = (response, translationCursor) => {
+const setTranslationHashCookie = (response, translationCursor) => {
     let headers = response.headers;
     headers = setHeader(headers, 'Set-Cookie', `translation-hash=${translationCursor}`);
     return Object.assign(Object.assign({}, response), { headers });

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -134,14 +134,16 @@ function getHandler(config) {
     const handler = (event) => __awaiter(this, void 0, void 0, function* () {
         let response = event.Records[0].cf.response;
         const request = event.Records[0].cf.request;
-        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER);
-        const treeHash = getHeader(request, TREE_HASH_HEADER);
         response = addSecurityHeaders(response, config);
         response = addCacheHeader(response);
         response = addRobotsHeader(response, config);
-        response = setTranslationHashCookie(response, translationCursor);
-        if (Boolean(translationCursor)) {
-            response = addPreloadHeader(response, request, translationCursor, treeHash);
+        if (config.isLocalised === 'true') {
+            const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER);
+            const treeHash = getHeader(request, TREE_HASH_HEADER);
+            response = setTranslationHashCookie(response, translationCursor);
+            if (Boolean(translationCursor)) {
+                response = addPreloadHeader(response, request, translationCursor, treeHash);
+            }
         }
         return response;
     });

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -86,6 +86,9 @@ function getHeader(request, headerName) {
     return (_c = (_b = (_a = request.headers) === null || _a === void 0 ? void 0 : _a[headerName.toLowerCase()]) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.value;
 }
 const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor';
+// If something goes wrong in any of the step for retrieving latest translation cursor, the value will be defaulted to 'default'
+// If translation cursor is 'default', on the client side only english will available and messages will be get from the file deployed during app deploy
+const DEFAULT_TRANSLATION_CURSOR = 'default';
 
 ;// CONCATENATED MODULE: ./src/viewer-response/viewer-response.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -111,12 +114,14 @@ function getHandler(config) {
     const handler = (event) => __awaiter(this, void 0, void 0, function* () {
         let response = event.Records[0].cf.response;
         const request = event.Records[0].cf.request;
-        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER) || 'default';
+        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER) || DEFAULT_TRANSLATION_CURSOR;
         response = addSecurityHeaders(response, config);
         response = addCacheHeader(response);
         response = addRobotsHeader(response, config);
         response = addCookieHeader(response, translationCursor);
-        response = addPreloadHeader(response, request, translationCursor);
+        if (translationCursor !== DEFAULT_TRANSLATION_CURSOR) {
+            response = addPreloadHeader(response, request, translationCursor);
+        }
         return response;
     });
     return handler;

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -134,6 +134,15 @@ function utils_fetchFileFromS3Bucket(key, bucket, s3) {
 }
 
 ;// CONCATENATED MODULE: ./src/addons/translations.ts
+/**
+ * This addon adds the translations functionality to the SPA served. It uses a secondary cursor deployment.
+ * The latest version of translations is fetched when the HTML requested by the browser (at the same time as
+ * the latest version of the app is served). Then that version is returned together with the HTML response
+ * via a cookie header.
+ * Additionally, to improve performance, a preload link header is added to the HTML response to trigger fetching
+ * of the message catalog as soon as possible, without having to wait for the app JS to be downloaded, parsed
+ * and executed before making a request for the message catalog.
+ */
 var translations_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -150,15 +159,6 @@ const DEFAULT_LANGUAGE = 'en';
 const LANG_QUERY_PARAM = 'lang';
 const LANG_COOKIE_NAME = 'x-pleo-language';
 const TRANSLATION_VERSION_COOKIE_NAME = 'translation-version';
-/**
- * This addon adds the translations functionality to the SPA served. It uses a secondary cursor deployment.
- * The latest version of translations is fetched when the HTML requested by the browser (at the same time as
- * the latest version of the app is served). Then that version is returned together with the HTML response
- * via a cookie header.
- * Additionally, to improve performance, a preload link header is added to the HTML response to trigger fetching
- * of the message catalog as soon as possible, without having to wait for the app JS to be downloaded, parsed
- * and executed before making a request for the message catalog.
- */
 /**
  * Modifies the response object to enrich it with headers used to serve translations for the app.
  */
@@ -199,7 +199,7 @@ function addTranslationInfoToRequest({ request, translationVersion, appVersion, 
  */
 const setTranslationVersionCookie = (response, translationVersion) => {
     let headers = response.headers;
-    headers = utils_setHeader(headers, 'Set-Cookie', `${TRANSLATION_VERSION_COOKIE_NAME}=${translationVersion}`);
+    headers = utils_setHeader(headers, 'Set-Cookie', `${TRANSLATION_VERSION_COOKIE_NAME}=${translationVersion}`, { merge: true });
     return Object.assign(Object.assign({}, response), { headers });
 };
 /**

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -61,6 +61,15 @@ function getConfig() {
 }
 
 ;// CONCATENATED MODULE: ./src/utils.ts
+var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 /**
  * Appends a custom header to a passed CloudFront header map
  * @param headers - CloudFront headers map
@@ -69,7 +78,7 @@ function getConfig() {
  * @param options.merge - Should the current header value be merged with the new one (e.g. for cookies)
  * @returns A new, modified CloudFront header maps
  */
-function setHeader(headers, headerName, headerValue, options = {}) {
+function utils_setHeader(headers, headerName, headerValue, options = {}) {
     var _a;
     const headerKey = headerName.toLowerCase();
     const previousHeader = options.merge ? (_a = headers[headerKey]) !== null && _a !== void 0 ? _a : [] : [];
@@ -85,8 +94,6 @@ function getHeader(request, headerName) {
     var _a, _b, _c;
     return (_c = (_b = (_a = request.headers) === null || _a === void 0 ? void 0 : _a[headerName.toLowerCase()]) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.value;
 }
-const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor';
-const TREE_HASH_HEADER = 'X-Tree-Hash';
 /**
  * Extract the value of a specific cookie from CloudFront headers map, if present
  * @param headers - CloudFront headers map
@@ -109,9 +116,25 @@ function getCookie(headers, cookieName) {
     }
     return null;
 }
+/**
+ * Fetches a file from the S3 origin bucket and returns its content
+ * @param key key for the S3 bucket
+ * @param bucket name of the S3 bucket
+ * @param s3 S3 instance
+ * @returns content of the file
+ */
+function utils_fetchFileFromS3Bucket(key, bucket, s3) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield s3.getObject({ Bucket: bucket, Key: key }).promise();
+        if (!response.Body) {
+            throw new Error(`Empty response from S3 for ${key} in ${bucket} bucket`);
+        }
+        return response.Body.toString('utf-8').trim();
+    });
+}
 
-;// CONCATENATED MODULE: ./src/viewer-response/viewer-response.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+;// CONCATENATED MODULE: ./src/addons/translations.ts
+var translations_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -120,6 +143,123 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+
+const TRANSLATION_VERSION_HEADER = 'X-Translation-Version';
+const APP_VERSION_HEADER = 'X-App-Version';
+const DEFAULT_LANGUAGE = 'en';
+const LANG_QUERY_PARAM = 'lang';
+const LANG_COOKIE_NAME = 'x-pleo-language';
+const TRANSLATION_VERSION_COOKIE_NAME = 'translation-version';
+/**
+ * This addon adds the translations functionality to the SPA served. It uses a secondary cursor deployment.
+ * The latest version of translations is fetched when the HTML requested by the browser (at the same time as
+ * the latest version of the app is served). Then that version is returned together with the HTML response
+ * via a cookie header.
+ * Additionally, to improve performance, a preload link header is added to the HTML response to trigger fetching
+ * of the message catalog as soon as possible, without having to wait for the app JS to be downloaded, parsed
+ * and executed before making a request for the message catalog.
+ */
+/**
+ * Modifies the response object to enrich it with headers used to serve translations for the app.
+ */
+function addTranslationInfoToResponse(response, request, config) {
+    if (config.isLocalised !== 'true') {
+        return response;
+    }
+    const translationVersion = getHeader(request, TRANSLATION_VERSION_HEADER);
+    const appVersion = getHeader(request, APP_VERSION_HEADER);
+    let modifiedResponse = setTranslationVersionCookie(response, translationVersion);
+    if (Boolean(translationVersion)) {
+        modifiedResponse = addPreloadHeader({
+            response: modifiedResponse,
+            request,
+            translationVersion,
+            appVersion
+        });
+    }
+    return modifiedResponse;
+}
+/**
+ * Modifies the pass request object to add the app and translation version on the request
+ * object as custom headers. This allows the viewer-response lambda to pick up this information
+ * and use it enrich the response.
+ */
+function addTranslationInfoToRequest({ request, translationVersion, appVersion, config }) {
+    if (!config.isLocalised) {
+        return;
+    }
+    if (translationVersion) {
+        request.headers = setHeader(request.headers, TRANSLATION_VERSION_HEADER, translationVersion);
+    }
+    request.headers = setHeader(request.headers, APP_VERSION_HEADER, appVersion);
+}
+/**
+ * Adds a cookie with the current translation version. This value is used by the app to request
+ * the translation catalog (for any language other than the default language)
+ */
+const setTranslationVersionCookie = (response, translationVersion) => {
+    let headers = response.headers;
+    headers = utils_setHeader(headers, 'Set-Cookie', `${TRANSLATION_VERSION_COOKIE_NAME}=${translationVersion}`);
+    return Object.assign(Object.assign({}, response), { headers });
+};
+/**
+ * Adds preload header for translation file to speed up rendering of the app. It's crucial to fetch the
+ * translations file as soon as possible, since we can't render anything without the translated messages.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+ *
+ * The file we ask the browser to pre-fetch is our best guess based on:
+ * - the language query param sometimes set on redirects to the app - this takes precedence
+ * - the language stored in a cookie, which we set whenever the user selects a language in the app
+ * - falling back to the default language when none of the above is set
+ *
+ * Note that this guess is not guaranteed to be the file that the app will actually request to fetch.
+ * In that case, we will have pre-fetched the wrong file and a second translation file will need to be
+ * fetched. The app will still work, alas slower.
+ */
+const addPreloadHeader = ({ response, request, translationVersion, appVersion }) => {
+    var _a, _b;
+    let headers = response.headers;
+    const urlParams = new URLSearchParams(request.querystring);
+    const language = (_b = (_a = urlParams.get(LANG_QUERY_PARAM)) !== null && _a !== void 0 ? _a : getCookie(request.headers, LANG_COOKIE_NAME)) !== null && _b !== void 0 ? _b : DEFAULT_LANGUAGE;
+    // If the language guessed is the default language, instead of using the translation version,
+    // we use the version of the app. The default language is deployed together with the app, and not
+    // separately, so it follows the app versioning and the translations versioning.
+    const hash = language === DEFAULT_LANGUAGE ? appVersion : translationVersion;
+    headers = utils_setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`);
+    return Object.assign(Object.assign({}, response), { headers });
+};
+/**
+ * Get the latest translation cursor file from S3 bucket
+ */
+const getTranslationVersion = (s3, config) => translations_awaiter(void 0, void 0, void 0, function* () {
+    try {
+        if (!config.isLocalised) {
+            return;
+        }
+        const response = yield fetchFileFromS3Bucket('translation-deploy/latest', config.originBucketName, s3);
+        return response;
+    }
+    catch (error) {
+        console.error(error);
+        // We never want this function to throw to avoid the app failing on any issues with the translations
+        // deployments. We return an empty translation version here, which means the app will fall back to the
+        // default language (which uses the app version instead of the translations version)
+        return undefined;
+    }
+});
+
+;// CONCATENATED MODULE: ./src/viewer-response/viewer-response.ts
+var viewer_response_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
 
 /**
  * Edge Lambda handler triggered on "viewer-response" event, on the default CF behavior of the web app CF distribution.
@@ -131,20 +271,13 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * We're going via a getHandler method to aid testing with dependency injection
  */
 function getHandler(config) {
-    const handler = (event) => __awaiter(this, void 0, void 0, function* () {
+    const handler = (event) => viewer_response_awaiter(this, void 0, void 0, function* () {
         let response = event.Records[0].cf.response;
         const request = event.Records[0].cf.request;
         response = addSecurityHeaders(response, config);
         response = addCacheHeader(response);
         response = addRobotsHeader(response, config);
-        if (config.isLocalised === 'true') {
-            const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER);
-            const treeHash = getHeader(request, TREE_HASH_HEADER);
-            response = setTranslationHashCookie(response, translationCursor);
-            if (Boolean(translationCursor)) {
-                response = addPreloadHeader(response, request, translationCursor, treeHash);
-            }
-        }
+        response = addTranslationInfoToResponse(response, request, config);
         return response;
     });
     return handler;
@@ -156,14 +289,14 @@ const addSecurityHeaders = (response, config) => {
     let headers = response.headers;
     if (config.blockIframes === 'true') {
         // prevent embedding inside an iframe
-        headers = setHeader(headers, 'X-Frame-Options', 'DENY');
+        headers = utils_setHeader(headers, 'X-Frame-Options', 'DENY');
     }
     // prevent mime type sniffing
-    headers = setHeader(headers, 'X-Content-Type-Options', 'nosniff');
+    headers = utils_setHeader(headers, 'X-Content-Type-Options', 'nosniff');
     // prevent exposing referer information outside of the origin
-    headers = setHeader(headers, 'Referrer-Policy', 'same-origin');
+    headers = utils_setHeader(headers, 'Referrer-Policy', 'same-origin');
     // prevent rendering of page if XSS attack is detected
-    headers = setHeader(headers, 'X-XSS-Protection', '1; mode=block');
+    headers = utils_setHeader(headers, 'X-XSS-Protection', '1; mode=block');
     return Object.assign(Object.assign({}, response), { headers });
 };
 /**
@@ -174,7 +307,7 @@ const addSecurityHeaders = (response, config) => {
  */
 const addCacheHeader = (response) => {
     let headers = response.headers;
-    headers = setHeader(headers, 'Cache-Control', 'max-age=0,no-cache,no-store,must-revalidate');
+    headers = utils_setHeader(headers, 'Cache-Control', 'max-age=0,no-cache,no-store,must-revalidate');
     return Object.assign(Object.assign({}, response), { headers });
 };
 /**
@@ -183,33 +316,8 @@ const addCacheHeader = (response) => {
 const addRobotsHeader = (response, config) => {
     let headers = response.headers;
     if (config.blockRobots === 'true') {
-        headers = setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow');
+        headers = utils_setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow');
     }
-    return Object.assign(Object.assign({}, response), { headers });
-};
-/**
- * Adds cookie 'translation-hash' with value of latest translation cursor
- */
-const setTranslationHashCookie = (response, translationCursor) => {
-    let headers = response.headers;
-    headers = setHeader(headers, 'Set-Cookie', `translation-hash=${translationCursor}`);
-    return Object.assign(Object.assign({}, response), { headers });
-};
-/**
- * Adds preload header for translation file to speed up rendering of the app,
- * since translation file is the required for it.
- * We get the language from the 'x-pleo-language' cookie
- * which is in sync with the user language to preload translation file with the language of the app.
- * But it is possible to override user&app language with the 'lang' url param,
- * since this overriding won't be refltected in the cookie yet, we get the language from this param 'lang'
- * If both, url param & cookie are empty, it means that language is not chosen by any form, which means that the app will be in 'en'
- */
-const addPreloadHeader = (response, request, translationCursor, treeHash) => {
-    let headers = response.headers;
-    const urlParams = new URLSearchParams(request.querystring);
-    const language = urlParams.get('lang') || getCookie(request.headers, 'x-pleo-language') || 'en';
-    const hash = language === 'en' ? treeHash : translationCursor;
-    headers = setHeader(headers, 'Link', `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`);
     return Object.assign(Object.assign({}, response), { headers });
 };
 

--- a/edge-lambdas/dist/viewer-response/index.js
+++ b/edge-lambdas/dist/viewer-response/index.js
@@ -206,7 +206,7 @@ const setTranslationVersionCookie = (response, translationVersion) => {
  * Adds preload header for translation file to speed up rendering of the app. It's crucial to fetch the
  * translations file as soon as possible, since we can't render anything without the translated messages.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
  *
  * The file we ask the browser to pre-fetch is our best guess based on:
  * - the language query param sometimes set on redirects to the app - this takes precedence
@@ -241,7 +241,7 @@ const getTranslationVersion = (s3, config) => translations_awaiter(void 0, void 
         return response;
     }
     catch (error) {
-        console.error(error);
+        console.error('getTranslationVersion failed', error);
         // We never want this function to throw to avoid the app failing on any issues with the translations
         // deployments. We return an empty translation version here, which means the app will fall back to the
         // default language (which uses the app version instead of the translations version)

--- a/edge-lambdas/src/addons/translations.ts
+++ b/edge-lambdas/src/addons/translations.ts
@@ -99,7 +99,7 @@ export const setTranslationVersionCookie = (
  * Adds preload header for translation file to speed up rendering of the app. It's crucial to fetch the
  * translations file as soon as possible, since we can't render anything without the translated messages.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
  *
  * The file we ask the browser to pre-fetch is our best guess based on:
  * - the language query param sometimes set on redirects to the app - this takes precedence

--- a/edge-lambdas/src/addons/translations.ts
+++ b/edge-lambdas/src/addons/translations.ts
@@ -158,7 +158,7 @@ export const getTranslationVersion = async (s3: S3, config: Config) => {
         )
         return response
     } catch (error) {
-        console.error(error)
+        console.error('getTranslationVersion failed', error)
         // We never want this function to throw to avoid the app failing on any issues with the translations
         // deployments. We return an empty translation version here, which means the app will fall back to the
         // default language (which uses the app version instead of the translations version)

--- a/edge-lambdas/src/addons/translations.ts
+++ b/edge-lambdas/src/addons/translations.ts
@@ -1,0 +1,167 @@
+/**
+ * This addon adds the translations functionality to the SPA served. It uses a secondary cursor deployment.
+ * The latest version of translations is fetched when the HTML requested by the browser (at the same time as
+ * the latest version of the app is served). Then that version is returned together with the HTML response
+ * via a cookie header.
+ * Additionally, to improve performance, a preload link header is added to the HTML response to trigger fetching
+ * of the message catalog as soon as possible, without having to wait for the app JS to be downloaded, parsed
+ * and executed before making a request for the message catalog.
+ */
+
+import {CloudFrontRequest, CloudFrontResponse} from 'aws-lambda'
+import {S3} from 'aws-sdk'
+import {Config} from '../config'
+import {fetchFileFromS3Bucket, getCookie, getHeader, setHeader} from '../utils'
+
+const TRANSLATION_VERSION_HEADER = 'X-Translation-Version'
+const APP_VERSION_HEADER = 'X-App-Version'
+const DEFAULT_LANGUAGE = 'en'
+const LANG_QUERY_PARAM = 'lang'
+const LANG_COOKIE_NAME = 'x-pleo-language'
+const TRANSLATION_VERSION_COOKIE_NAME = 'translation-version'
+
+/**
+ * Modifies the response object to enrich it with headers used to serve translations for the app.
+ */
+export function addTranslationInfoToResponse(
+    response: CloudFrontResponse,
+    request: CloudFrontRequest,
+    config: Config
+) {
+    if (config.isLocalised !== 'true') {
+        return response
+    }
+
+    const translationVersion = getHeader(request, TRANSLATION_VERSION_HEADER)
+    const appVersion = getHeader(request, APP_VERSION_HEADER)
+
+    let modifiedResponse = setTranslationVersionCookie(response, translationVersion)
+
+    if (Boolean(translationVersion)) {
+        modifiedResponse = addPreloadHeader({
+            response: modifiedResponse,
+            request,
+            translationVersion,
+            appVersion
+        })
+    }
+
+    return modifiedResponse
+}
+
+/**
+ * Modifies the pass request object to add the app and translation version on the request
+ * object as custom headers. This allows the viewer-response lambda to pick up this information
+ * and use it enrich the response.
+ */
+export function addTranslationInfoToRequest({
+    request,
+    translationVersion,
+    appVersion,
+    config
+}: {
+    request: CloudFrontRequest
+    translationVersion: string
+    appVersion: string
+    config: Config
+}) {
+    if (!config.isLocalised) {
+        return
+    }
+
+    if (translationVersion) {
+        request.headers = setHeader(request.headers, TRANSLATION_VERSION_HEADER, translationVersion)
+    }
+    request.headers = setHeader(request.headers, APP_VERSION_HEADER, appVersion)
+}
+
+/**
+ * Adds a cookie with the current translation version. This value is used by the app to request
+ * the translation catalog (for any language other than the default language)
+ */
+export const setTranslationVersionCookie = (
+    response: CloudFrontResponse,
+    translationVersion: string
+) => {
+    let headers = response.headers
+
+    headers = setHeader(
+        headers,
+        'Set-Cookie',
+        `${TRANSLATION_VERSION_COOKIE_NAME}=${translationVersion}`,
+        {merge: true}
+    )
+
+    return {...response, headers}
+}
+
+/**
+ * Adds preload header for translation file to speed up rendering of the app. It's crucial to fetch the
+ * translations file as soon as possible, since we can't render anything without the translated messages.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload
+ *
+ * The file we ask the browser to pre-fetch is our best guess based on:
+ * - the language query param sometimes set on redirects to the app - this takes precedence
+ * - the language stored in a cookie, which we set whenever the user selects a language in the app
+ * - falling back to the default language when none of the above is set
+ *
+ * Note that this guess is not guaranteed to be the file that the app will actually request to fetch.
+ * In that case, we will have pre-fetched the wrong file and a second translation file will need to be
+ * fetched. The app will still work, alas slower.
+ */
+export const addPreloadHeader = ({
+    response,
+    request,
+    translationVersion,
+    appVersion
+}: {
+    response: CloudFrontResponse
+    request: CloudFrontRequest
+    translationVersion: string
+    appVersion: string
+}) => {
+    let headers = response.headers
+    const urlParams = new URLSearchParams(request.querystring)
+
+    const language =
+        urlParams.get(LANG_QUERY_PARAM) ??
+        getCookie(request.headers, LANG_COOKIE_NAME) ??
+        DEFAULT_LANGUAGE
+
+    // If the language guessed is the default language, instead of using the translation version,
+    // we use the version of the app. The default language is deployed together with the app, and not
+    // separately, so it follows the app versioning and the translations versioning.
+    const hash = language === DEFAULT_LANGUAGE ? appVersion : translationVersion
+
+    headers = setHeader(
+        headers,
+        'Link',
+        `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`
+    )
+
+    return {...response, headers}
+}
+
+/**
+ * Get the latest translation cursor file from S3 bucket
+ */
+export const getTranslationVersion = async (s3: S3, config: Config) => {
+    try {
+        if (!config.isLocalised) {
+            return
+        }
+        const response = await fetchFileFromS3Bucket(
+            'translation-deploy/latest',
+            config.originBucketName,
+            s3
+        )
+        return response
+    } catch (error) {
+        console.error(error)
+        // We never want this function to throw to avoid the app failing on any issues with the translations
+        // deployments. We return an empty translation version here, which means the app will fall back to the
+        // default language (which uses the app version instead of the translations version)
+        return undefined
+    }
+}

--- a/edge-lambdas/src/config.ts
+++ b/edge-lambdas/src/config.ts
@@ -16,5 +16,6 @@ export type Config = {
     previewDeploymentPostfix?: string
     defaultBranchName?: string
     blockIframes?: string
+    isLocalised?: string
     blockRobots?: string
 }

--- a/edge-lambdas/src/utils.test.ts
+++ b/edge-lambdas/src/utils.test.ts
@@ -1,0 +1,77 @@
+import {getCookie} from './utils'
+
+describe(`getCookie`, () => {
+    test(`
+        default run
+    `, async () => {
+        const pleoAbUniqueIdValue = 'FSf7ljORURe556Kk8-KOL'
+        const value = getCookie(
+            {
+                cookie: [
+                    {
+                        key: 'cookie',
+                        value: `pleo-ab-unique-id=${pleoAbUniqueIdValue}; _ga=GA1.2.766092372.1651495092;`
+                    }
+                ]
+            },
+            'pleo-ab-unique-id'
+        )
+
+        expect(value).toBe(pleoAbUniqueIdValue)
+    })
+
+    test(`
+    empty cookie header
+`, async () => {
+        const value = getCookie(
+            {
+                cookie: undefined
+            },
+            'pleo-ab-unique-id'
+        )
+
+        expect(value).toBe(null)
+
+        const valueWithEmptyArray = getCookie(
+            {
+                cookie: []
+            },
+            'pleo-ab-unique-id'
+        )
+
+        expect(valueWithEmptyArray).toBe(null)
+
+        const valueWithEmptyCookieValue = getCookie(
+            {
+                cookie: [
+                    {
+                        key: 'cookie',
+                        value: ''
+                    }
+                ]
+            },
+            'pleo-ab-unique-id'
+        )
+
+        expect(valueWithEmptyCookieValue).toBe(null)
+    })
+
+    test(`
+    return null with no cookie with such name
+`, async () => {
+        const pleoAbUniqueIdValue = 'FSf7ljORURe556Kk8-KOL'
+        const value = getCookie(
+            {
+                cookie: [
+                    {
+                        key: 'cookie',
+                        value: `pleo-ab-unique-ok=${pleoAbUniqueIdValue}; _ga=GA1.2.766092372.1651495092;`
+                    }
+                ]
+            },
+            'pleo-ab-unique-id'
+        )
+
+        expect(value).toBe(null)
+    })
+})

--- a/edge-lambdas/src/utils.test.ts
+++ b/edge-lambdas/src/utils.test.ts
@@ -1,9 +1,7 @@
 import {getCookie} from './utils'
 
 describe(`getCookie`, () => {
-    test(`
-        default run
-    `, async () => {
+    test(`default run`, async () => {
         const pleoAbUniqueIdValue = 'FSf7ljORURe556Kk8-KOL'
         const value = getCookie(
             {
@@ -20,9 +18,7 @@ describe(`getCookie`, () => {
         expect(value).toBe(pleoAbUniqueIdValue)
     })
 
-    test(`
-    empty cookie header
-`, async () => {
+    test(`empty cookie header`, async () => {
         const value = getCookie(
             {
                 cookie: undefined
@@ -56,9 +52,7 @@ describe(`getCookie`, () => {
         expect(valueWithEmptyCookieValue).toBe(null)
     })
 
-    test(`
-    return null with no cookie with such name
-`, async () => {
+    test(`return null with no cookie with such name`, async () => {
         const pleoAbUniqueIdValue = 'FSf7ljORURe556Kk8-KOL'
         const value = getCookie(
             {

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -31,3 +31,5 @@ export function setHeader(
 export function getHeader(request: CloudFrontRequest, headerName: string): string | undefined {
     return request.headers?.[headerName.toLowerCase()]?.[0]?.value
 }
+
+export const TRANSLATION_CURSOR_HEADER = 'Translation-Cursor'

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -33,3 +33,4 @@ export function getHeader(request: CloudFrontRequest, headerName: string): strin
 }
 
 export const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor'
+export const DEFAULT_TRANSLATION_CURSOR = 'default'

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -33,4 +33,7 @@ export function getHeader(request: CloudFrontRequest, headerName: string): strin
 }
 
 export const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor'
+
+// If something goes wrong in any of the step for retrieving latest translation cursor, the value will be defaulted to 'default'
+// If translation cursor is 'default', on the client side only english will available and messages will be get from the file deployed during app deploy
 export const DEFAULT_TRANSLATION_CURSOR = 'default'

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -33,6 +33,7 @@ export function getHeader(request: CloudFrontRequest, headerName: string): strin
 }
 
 export const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor'
+export const TREE_HASH_HEADER = 'X-Tree-Hash'
 
 // If something goes wrong in any of the step for retrieving latest translation cursor, the value will be defaulted to 'default'
 // If translation cursor is 'default', on the client side only english will available and messages will be get from the file deployed during app deploy

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -38,3 +38,31 @@ export const TREE_HASH_HEADER = 'X-Tree-Hash'
 // If something goes wrong in any of the step for retrieving latest translation cursor, the value will be defaulted to 'default'
 // If translation cursor is 'default', on the client side only english will available and messages will be get from the file deployed during app deploy
 export const DEFAULT_TRANSLATION_CURSOR = 'default'
+
+/**
+ * Extract the value of a specific cookie from CloudFront headers map, if present
+ * @param headers - CloudFront headers map
+ * @param cookieName - The key of the cookie to extract the value for
+ * @returns The string value of the cookie if present, otherwise null
+ */
+export function getCookie(headers: CloudFrontHeaders, cookieName: string) {
+    const cookieHeader = headers.cookie
+
+    if (!cookieHeader) {
+        return null
+    }
+
+    for (const cookieSet of cookieHeader) {
+        const cookies = cookieSet.value.split(/; /)
+
+        for (const cookie of cookies) {
+            const cookieKeyValue = cookie.split('=')
+
+            if (cookieKeyValue[0] === cookieName) {
+                return cookieKeyValue[1]
+            }
+        }
+    }
+
+    return null
+}

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -34,11 +34,6 @@ export function getHeader(request: CloudFrontRequest, headerName: string): strin
 
 export const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor'
 export const TREE_HASH_HEADER = 'X-Tree-Hash'
-
-// If something goes wrong in any of the step for retrieving latest translation cursor, the value will be defaulted to 'default'
-// If translation cursor is 'default', on the client side only english will available and messages will be get from the file deployed during app deploy
-export const DEFAULT_TRANSLATION_CURSOR = 'default'
-
 /**
  * Extract the value of a specific cookie from CloudFront headers map, if present
  * @param headers - CloudFront headers map

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -32,4 +32,4 @@ export function getHeader(request: CloudFrontRequest, headerName: string): strin
     return request.headers?.[headerName.toLowerCase()]?.[0]?.value
 }
 
-export const TRANSLATION_CURSOR_HEADER = 'Translation-Cursor'
+export const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor'

--- a/edge-lambdas/src/utils.ts
+++ b/edge-lambdas/src/utils.ts
@@ -1,4 +1,5 @@
 import {CloudFrontHeaders, CloudFrontRequest} from 'aws-lambda'
+import {S3} from 'aws-sdk'
 
 /**
  * Appends a custom header to a passed CloudFront header map
@@ -28,12 +29,10 @@ export function setHeader(
  * @param headerName - Header name to retrieve
  * @returns The first found value of the specified header, if available
  */
-export function getHeader(request: CloudFrontRequest, headerName: string): string | undefined {
+export function getHeader(request: CloudFrontRequest, headerName: string) {
     return request.headers?.[headerName.toLowerCase()]?.[0]?.value
 }
 
-export const TRANSLATION_CURSOR_HEADER = 'X-Translation-Cursor'
-export const TREE_HASH_HEADER = 'X-Tree-Hash'
 /**
  * Extract the value of a specific cookie from CloudFront headers map, if present
  * @param headers - CloudFront headers map
@@ -60,4 +59,20 @@ export function getCookie(headers: CloudFrontHeaders, cookieName: string) {
     }
 
     return null
+}
+
+/**
+ * Fetches a file from the S3 origin bucket and returns its content
+ * @param key key for the S3 bucket
+ * @param bucket name of the S3 bucket
+ * @param s3 S3 instance
+ * @returns content of the file
+ */
+export async function fetchFileFromS3Bucket(key: string, bucket: string, s3: S3) {
+    const response = await s3.getObject({Bucket: bucket, Key: key}).promise()
+    if (!response.Body) {
+        throw new Error(`Empty response from S3 for ${key} in ${bucket} bucket`)
+    }
+
+    return response.Body.toString('utf-8').trim()
 }

--- a/edge-lambdas/src/viewer-request/index.ts
+++ b/edge-lambdas/src/viewer-request/index.ts
@@ -7,9 +7,11 @@ import {getHandler} from './viewer-request'
 
 const config = getConfig()
 
-// Note that in order to optimise performance, we're using a persistent connection created
-// in global scope of this Edge Lambda. See https://aws.amazon.com/blogs/networking-and-content-delivery/leveraging-external-data-in-lambdaedge
-// for more details.
+/**
+ * Note that in order to optimize performance, we're using a persistent connection created
+ * in global scope of this Edge Lambda. For more details
+ * @see https://aws.amazon.com/blogs/networking-and-content-delivery/leveraging-external-data-in-lambdaedge
+ */
 const keepAliveAgent = new https.Agent({keepAlive: true})
 const s3 = new S3({
     region: config.originBucketRegion,

--- a/edge-lambdas/src/viewer-request/viewer-request.test.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.test.ts
@@ -22,18 +22,27 @@ describe(`Viewer request Lambda@Edge`, () => {
             },
             s3
         )
-        const event = mockRequestEvent({host: 'app.example.com'})
+        const event = mockRequestEvent({host: 'app.example.com', hash: treeHash})
 
         const response = await handler(event, {} as any, () => {})
+
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
 
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-prod',
             Key: `deploys/master`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-prod',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: 'app.example.com',
+                    hash: treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -56,18 +65,27 @@ describe(`Viewer request Lambda@Edge`, () => {
             },
             s3
         )
-        const event = mockRequestEvent({host: 'app.example.com'})
+        const event = mockRequestEvent({host: 'app.example.com', hash: treeHash})
 
         const response = await handler(event, {} as any, () => {})
+
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
 
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-prod',
             Key: `deploys/main`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-prod',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: 'app.example.com',
+                    hash: treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -89,18 +107,27 @@ describe(`Viewer request Lambda@Edge`, () => {
             },
             s3
         )
-        const event = mockRequestEvent({host: 'app.staging.example.com'})
+        const event = mockRequestEvent({host: 'app.staging.example.com', hash: treeHash})
 
         const response = await handler(event, {} as any, () => {})
+
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
 
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-staging',
             Key: `deploys/master`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-staging',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: 'app.staging.example.com',
+                    hash: treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -122,18 +149,27 @@ describe(`Viewer request Lambda@Edge`, () => {
             },
             s3
         )
-        const event = mockRequestEvent({host: 'my-feature.app.staging.example.com'})
+        const event = mockRequestEvent({host: 'my-feature.app.staging.example.com', hash: treeHash})
 
         const response = await handler(event, {} as any, () => {})
+
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
 
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-staging',
             Key: `deploys/my-feature`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-staging',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: 'my-feature.app.staging.example.com',
+                    hash: treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -153,19 +189,29 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
         const event = mockRequestEvent({
             host: 'my-feature.app.staging.example.com',
+            hash: treeHash,
             uri: '/iframe.html'
         })
 
         const response = await handler(event, {} as any, () => {})
 
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
+
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-staging',
             Key: `deploys/my-feature`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-staging',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: 'my-feature.app.staging.example.com',
+                    hash: treeHash,
                     uri: `/html/${treeHash}/iframe.html`
                 })
             )
@@ -185,19 +231,29 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
         const event = mockRequestEvent({
             host: 'my-feature.app.staging.example.com',
+            hash: treeHash,
             uri: '/.well-known/apple-app-site-association'
         })
 
         const response = await handler(event, {} as any, () => {})
 
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
+
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-staging',
             Key: `deploys/my-feature`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-staging',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: 'my-feature.app.staging.example.com',
+                    hash: treeHash,
                     uri: `/html/${treeHash}/.well-known/apple-app-site-association`
                 })
             )
@@ -221,16 +277,23 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
 
         const event = mockRequestEvent({
-            host: `preview-${requestedTreeHash}.app.staging.example.com`
+            host: `preview-${requestedTreeHash}.app.staging.example.com`,
+            hash: treeHash
         })
 
         const response = await handler(event, {} as any, () => {})
 
-        expect(s3.getObject).not.toHaveBeenCalled()
+        expect(s3.getObject).toHaveBeenCalledTimes(1)
+
+        expect(s3.getObject).toHaveBeenCalledWith({
+            Bucket: 'test-origin-bucket-staging',
+            Key: 'translation-deploy/latest'
+        })
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: `preview-${requestedTreeHash}.app.staging.example.com`,
+                    hash: treeHash,
                     uri: `/html/${requestedTreeHash}/index.html`
                 })
             )
@@ -256,20 +319,30 @@ describe(`Viewer request Lambda@Edge`, () => {
             s3
         )
         const event = mockRequestEvent({
-            host: 'what-is-this-branch.app.staging.example.com'
+            host: 'what-is-this-branch.app.staging.example.com',
+            hash: '123'
         })
 
         const response = await handler(event, {} as any, () => {})
+
+        expect(s3.getObject).toHaveBeenCalledTimes(2)
 
         expect(s3.getObject).toHaveBeenCalledWith({
             Bucket: 'test-origin-bucket-staging',
             Key: `deploys/what-is-this-branch`
         })
+
+        expect(s3.getObject).toHaveBeenLastCalledWith({
+            Bucket: 'test-origin-bucket-staging',
+            Key: 'translation-deploy/latest'
+        })
+
         expect(response).toEqual(
             requestFromEvent(
                 mockRequestEvent({
                     host: `what-is-this-branch.app.staging.example.com`,
-                    uri: `/404`
+                    uri: `/404`,
+                    hash: '123'
                 })
             )
         )
@@ -290,9 +363,11 @@ const mockGetObject = (returnValue: string) => {
 // more info on the shape of the request events for Edge Lambdas
 const mockRequestEvent = ({
     host,
+    hash,
     uri = '/'
 }: {
     host: string
+    hash: string
     uri?: string
 }): CloudFrontRequestEvent => ({
     Records: [
@@ -323,6 +398,12 @@ const mockRequestEvent = ({
                             {
                                 key: 'accept',
                                 value: '*/*'
+                            }
+                        ],
+                        'x-translation-cursor': [
+                            {
+                                key: 'X-Translation-Cursor',
+                                value: hash
                             }
                         ]
                     },

--- a/edge-lambdas/src/viewer-request/viewer-request.test.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.test.ts
@@ -1,6 +1,5 @@
 import {CloudFrontRequestEvent} from 'aws-lambda'
 import S3 from 'aws-sdk/clients/s3'
-import {DEFAULT_TRANSLATION_CURSOR} from '../utils'
 import {getHandler} from './viewer-request'
 
 jest.mock('aws-sdk/clients/s3', () => jest.fn().mockReturnValue({getObject: jest.fn()}))
@@ -319,7 +318,7 @@ describe(`Viewer request Lambda@Edge`, () => {
         })
 
         const response = await handler(event, {} as any, () => {})
-        console.log(event['Records'][0]['cf']['request']['headers'])
+
         expect(s3.getObject).toHaveBeenCalledTimes(1)
 
         expect(s3.getObject).toHaveBeenCalledWith({
@@ -440,9 +439,9 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: 'app.example.com',
-                    translationHash: DEFAULT_TRANSLATION_CURSOR,
+                    translationHash,
                     treeHash,
-                    uri: `/html/${treeHash}/index.html`
+                    uri: `/404`
                 })
             )
         )

--- a/edge-lambdas/src/viewer-request/viewer-request.test.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.test.ts
@@ -14,14 +14,7 @@ describe(`Viewer request Lambda@Edge`, () => {
     `, async () => {
         const treeHash = '3b6197b16baa26057a25fcd5d60a64c4c0765d18'
         const translationHash = '123456'
-        const s3 = new MockedS3()
-
-        s3.getObject = jest.fn().mockReturnValue({
-            promise: jest
-                .fn()
-                .mockReturnValueOnce({Body: treeHash})
-                .mockReturnValueOnce({Body: translationHash})
-        })
+        const s3 = mockGetObject(treeHash, translationHash)
 
         const handler = getHandler(
             {
@@ -33,7 +26,7 @@ describe(`Viewer request Lambda@Edge`, () => {
         const event = mockRequestEvent({
             host: 'app.example.com',
             translationHash,
-            hash: treeHash
+            treeHash
         })
 
         const response = await handler(event, {} as any, () => {})
@@ -55,7 +48,7 @@ describe(`Viewer request Lambda@Edge`, () => {
                 mockRequestEvent({
                     host: 'app.example.com',
                     translationHash,
-                    hash: treeHash,
+                    treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -68,7 +61,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         it modifies the request to fetch the latest default branch HTML
     `, async () => {
         const treeHash = '3b6197b16baa26057a25fcd5d60a64c4c0765d18'
-        const s3 = mockGetObject(treeHash)
+        const translationHash = '123456'
+        const s3 = mockGetObject(treeHash, translationHash)
 
         const handler = getHandler(
             {
@@ -78,7 +72,11 @@ describe(`Viewer request Lambda@Edge`, () => {
             },
             s3
         )
-        const event = mockRequestEvent({host: 'app.example.com', translationHash: treeHash})
+        const event = mockRequestEvent({
+            host: 'app.example.com',
+            translationHash,
+            treeHash
+        })
 
         const response = await handler(event, {} as any, () => {})
 
@@ -98,7 +96,8 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: 'app.example.com',
-                    translationHash: treeHash,
+                    translationHash,
+                    treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -111,7 +110,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         it modifies the request to fetch the latest default branch HTML
     `, async () => {
         const treeHash = '75703e9524292bfa57c259e0621c3ed6b53bfcf2'
-        const s3 = mockGetObject(treeHash)
+        const translationHash = '123456'
+        const s3 = mockGetObject(treeHash, translationHash)
         const handler = getHandler(
             {
                 originBucketName: 'test-origin-bucket-staging',
@@ -120,7 +120,11 @@ describe(`Viewer request Lambda@Edge`, () => {
             },
             s3
         )
-        const event = mockRequestEvent({host: 'app.staging.example.com', translationHash: treeHash})
+        const event = mockRequestEvent({
+            host: 'app.staging.example.com',
+            translationHash,
+            treeHash
+        })
 
         const response = await handler(event, {} as any, () => {})
 
@@ -140,7 +144,8 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: 'app.staging.example.com',
-                    translationHash: treeHash,
+                    translationHash,
+                    treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -152,7 +157,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         it modifies the request to fetch the latest HTML for my-feature branch
     `, async () => {
         const treeHash = '75703e9524292bfa57c259e0621c3ed6b53bfcf2'
-        const s3 = mockGetObject(treeHash)
+        const translationHash = '123456'
+        const s3 = mockGetObject(treeHash, translationHash)
 
         const handler = getHandler(
             {
@@ -164,7 +170,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
         const event = mockRequestEvent({
             host: 'my-feature.app.staging.example.com',
-            translationHash: treeHash
+            translationHash,
+            treeHash
         })
 
         const response = await handler(event, {} as any, () => {})
@@ -185,7 +192,8 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: 'my-feature.app.staging.example.com',
-                    translationHash: treeHash,
+                    translationHash,
+                    treeHash,
                     uri: `/html/${treeHash}/index.html`
                 })
             )
@@ -194,7 +202,8 @@ describe(`Viewer request Lambda@Edge`, () => {
 
     test(`Handles requests for specific html files`, async () => {
         const treeHash = 'ce4a66492551f1cd2fad5296ee94b8ea2667eac3'
-        const s3 = mockGetObject(treeHash)
+        const translationHash = '123456'
+        const s3 = mockGetObject(treeHash, translationHash)
         const handler = getHandler(
             {
                 originBucketName: 'test-origin-bucket-staging',
@@ -205,7 +214,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
         const event = mockRequestEvent({
             host: 'my-feature.app.staging.example.com',
-            translationHash: treeHash,
+            translationHash,
+            treeHash,
             uri: '/iframe.html'
         })
 
@@ -227,7 +237,8 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: 'my-feature.app.staging.example.com',
-                    translationHash: treeHash,
+                    translationHash,
+                    treeHash,
                     uri: `/html/${treeHash}/iframe.html`
                 })
             )
@@ -236,7 +247,8 @@ describe(`Viewer request Lambda@Edge`, () => {
 
     test(`Handles requests for well known files`, async () => {
         const treeHash = 'ce4a66492551f1cd2fad5296ee94b8ea2667eac3'
-        const s3 = mockGetObject(treeHash)
+        const translationHash = '123456'
+        const s3 = mockGetObject(treeHash, translationHash)
         const handler = getHandler(
             {
                 originBucketName: 'test-origin-bucket-staging',
@@ -247,7 +259,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
         const event = mockRequestEvent({
             host: 'my-feature.app.staging.example.com',
-            translationHash: treeHash,
+            treeHash,
+            translationHash,
             uri: '/.well-known/apple-app-site-association'
         })
 
@@ -269,7 +282,8 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: 'my-feature.app.staging.example.com',
-                    translationHash: treeHash,
+                    treeHash,
+                    translationHash,
                     uri: `/html/${treeHash}/.well-known/apple-app-site-association`
                 })
             )
@@ -280,9 +294,14 @@ describe(`Viewer request Lambda@Edge`, () => {
         When requesting a specific version i.e. preview-{treeHash}.app.staging.example.com
         it modifies the request to fetch the HTML for that tree hash
     `, async () => {
-        const treeHash = 'c43d9be8eaa4f0bb422d1c171769f674c5a1dd1c'
-        const requestedTreeHash = '83436472715537da0ee129412de8df6bc1287500'
-        const s3 = mockGetObject(treeHash)
+        const treeHash = 'treebe8eaa4f0bb422d1c171769f674c5a1dd1c'
+        const requestedTreeHash = 'reques72715537da0ee129412de8df6bc1287500'
+        const translationHash = '123456'
+        const s3 = new MockedS3()
+
+        s3.getObject = jest.fn().mockReturnValue({
+            promise: jest.fn().mockReturnValueOnce({Body: translationHash})
+        })
         const handler = getHandler(
             {
                 originBucketName: 'test-origin-bucket-staging',
@@ -294,11 +313,12 @@ describe(`Viewer request Lambda@Edge`, () => {
 
         const event = mockRequestEvent({
             host: `preview-${requestedTreeHash}.app.staging.example.com`,
-            translationHash: treeHash
+            translationHash,
+            treeHash
         })
 
         const response = await handler(event, {} as any, () => {})
-
+        console.log(event['Records'][0]['cf']['request']['headers'])
         expect(s3.getObject).toHaveBeenCalledTimes(1)
 
         expect(s3.getObject).toHaveBeenCalledWith({
@@ -309,7 +329,8 @@ describe(`Viewer request Lambda@Edge`, () => {
             requestFromEvent(
                 mockRequestEvent({
                     host: `preview-${requestedTreeHash}.app.staging.example.com`,
-                    translationHash: treeHash,
+                    translationHash,
+                    treeHash: requestedTreeHash,
                     uri: `/html/${requestedTreeHash}/index.html`
                 })
             )
@@ -320,6 +341,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         When requesting a preview of an unknown branch,
         it requests the non-existing file to trigger a 404 error
     `, async () => {
+        const treeHash = 'treebe8eaa4f0bb422d1c171769f674c5a1dd1c'
+        const translationHash = '123456'
         const s3 = new MockedS3()
         s3.getObject = jest.fn().mockReturnValue({
             promise: jest.fn().mockRejectedValue(new Error('network error, yo'))
@@ -336,7 +359,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         )
         const event = mockRequestEvent({
             host: 'what-is-this-branch.app.staging.example.com',
-            translationHash: '123'
+            treeHash,
+            translationHash
         })
 
         const response = await handler(event, {} as any, () => {})
@@ -358,7 +382,8 @@ describe(`Viewer request Lambda@Edge`, () => {
                 mockRequestEvent({
                     host: `what-is-this-branch.app.staging.example.com`,
                     uri: `/404`,
-                    translationHash: '123'
+                    treeHash,
+                    translationHash
                 })
             )
         )
@@ -366,24 +391,36 @@ describe(`Viewer request Lambda@Edge`, () => {
     })
 })
 
-const mockGetObject = (returnValue: string) => {
+// const mockGetObject = (returnValue: string) => {
+//     const s3 = new MockedS3()
+//     s3.getObject = jest.fn().mockReturnValue({
+//         promise: jest.fn().mockReturnValue({Body: returnValue})
+//     })
+//     return s3
+// }
+
+const mockGetObject = (firstValue: string, secondValue) => {
     const s3 = new MockedS3()
     s3.getObject = jest.fn().mockReturnValue({
-        promise: jest.fn().mockReturnValue({Body: returnValue})
+        promise: jest
+            .fn()
+            .mockReturnValueOnce({Body: firstValue})
+            .mockReturnValueOnce({Body: secondValue})
     })
     return s3
 }
+
 // Returns a mock Cloudfront viewer request event with the specified host and URI. See
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-viewer-request for
 // more info on the shape of the request events for Edge Lambdas
 const mockRequestEvent = ({
     host,
     translationHash,
-    hash,
+    treeHash,
     uri = '/'
 }: {
     host: string
-    hash?: string
+    treeHash: string
     translationHash: string
     uri?: string
 }): CloudFrontRequestEvent => ({
@@ -426,7 +463,7 @@ const mockRequestEvent = ({
                         'x-tree-hash': [
                             {
                                 key: 'X-Tree-Hash',
-                                value: hash || translationHash
+                                value: treeHash
                             }
                         ]
                     },

--- a/edge-lambdas/src/viewer-request/viewer-request.test.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.test.ts
@@ -1,534 +1,261 @@
+import crypto from 'crypto'
 import {CloudFrontRequestEvent} from 'aws-lambda'
 import S3 from 'aws-sdk/clients/s3'
 import {getHandler} from './viewer-request'
 
 jest.mock('aws-sdk/clients/s3', () => jest.fn().mockReturnValue({getObject: jest.fn()}))
-const MockedS3 = S3 as jest.MockedClass<typeof S3>
 
-beforeEach(() => jest.resetAllMocks())
+beforeEach(() => {
+    jest.resetAllMocks()
+})
+
+const originConfig = {
+    originBucketName: 'test-origin-bucket',
+    originBucketRegion: 'eu-west-1'
+}
+const mockContext = {} as any
+const mockCallback = () => {}
 
 describe(`Viewer request Lambda@Edge`, () => {
     test(`
         When requesting app.example.com
-        it modifies the request to fetch the latest master branch HTML
+        Then the request is modified to fetch the latest master branch HTML
     `, async () => {
-        const treeHash = '3b6197b16baa26057a25fcd5d60a64c4c0765d18'
-        const translationHash = '123456'
-        const s3 = mockGetObject(treeHash, translationHash)
+        const appVersion = getRandomSha()
+        const host = 'app.example.com'
+        const s3 = getMockedS3(appVersion)
+        const event = mockRequestEvent({host})
 
-        const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-prod',
-                originBucketRegion: 'eu-west-1',
-                isLocalised: 'true'
-            },
-            s3
-        )
-        const event = mockRequestEvent({
-            host: 'app.example.com',
-            translationHash,
-            treeHash
-        })
+        const handler = getHandler({...originConfig}, s3)
+        const request = await handler(event, mockContext, mockCallback)
 
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: `deploys/master`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'app.example.com',
-                    translationHash,
-                    treeHash,
-                    uri: `/html/${treeHash}/index.html`
-                })
-            )
-        )
-    })
-
-    test(`
-        No 'X-Translation-Cursor' & 'X-Tree-Hash' added when isLocalised='false' and no request to S3 to /latest translation hash
-    `, async () => {
-        const treeHash = '3b6197b16baa26057a25fcd5d60a64c4c0765d18'
-        const s3 = new MockedS3()
-        s3.getObject = jest.fn().mockReturnValue({
-            promise: jest.fn().mockReturnValue({Body: treeHash})
-        })
-
-        const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-prod',
-                originBucketRegion: 'eu-west-1',
-                isLocalised: 'false'
-            },
-            s3
-        )
-        const event = mockRequestEvent({
-            host: 'app.example.com'
-        })
-
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(1)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: `deploys/master`
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'app.example.com',
-                    uri: `/html/${treeHash}/index.html`
-                })
-            )
-        )
+        expectAppVersionFetched(s3, 'deploys/master')
+        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`
         When requesting app.example.com
-        and a custom default branch name is configured
-        it modifies the request to fetch the latest default branch HTML
+        And a custom default branch name is configured
+        Then it modifies the request to fetch the latest default branch HTML
     `, async () => {
-        const treeHash = '3b6197b16baa26057a25fcd5d60a64c4c0765d18'
-        const translationHash = '123456'
-        const s3 = mockGetObject(treeHash, translationHash)
+        const appVersion = getRandomSha()
+        const host = 'app.example.com'
+        const s3 = getMockedS3(appVersion)
+        const event = mockRequestEvent({host})
 
-        const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-prod',
-                originBucketRegion: 'eu-west-1',
-                defaultBranchName: 'main',
-                isLocalised: 'true'
-            },
-            s3
-        )
-        const event = mockRequestEvent({
-            host: 'app.example.com',
-            translationHash,
-            treeHash
-        })
+        const handler = getHandler({...originConfig, defaultBranchName: 'main'}, s3)
+        const request = await handler(event, mockContext, mockCallback)
 
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: `deploys/main`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'app.example.com',
-                    translationHash,
-                    treeHash,
-                    uri: `/html/${treeHash}/index.html`
-                })
-            )
-        )
+        expectAppVersionFetched(s3, 'deploys/main')
+        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`
         When requesting app.staging.example.com
-        and preview deployment postfix is set
-        it modifies the request to fetch the latest default branch HTML
+        And preview deployment postfix is set
+        Then it modifies the request to fetch the latest default branch HTML
     `, async () => {
-        const treeHash = '75703e9524292bfa57c259e0621c3ed6b53bfcf2'
-        const translationHash = '123456'
-        const s3 = mockGetObject(treeHash, translationHash)
+        const appVersion = getRandomSha()
+        const s3 = getMockedS3(appVersion)
+        const host = 'app.staging.example.com'
         const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-staging',
-                originBucketRegion: 'eu-west-1',
-                previewDeploymentPostfix: '.app.staging.example.com',
-                isLocalised: 'true'
-            },
+            {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             s3
         )
-        const event = mockRequestEvent({
-            host: 'app.staging.example.com',
-            translationHash,
-            treeHash
-        })
+        const event = mockRequestEvent({host})
 
-        const response = await handler(event, {} as any, () => {})
+        const request = await handler(event, mockContext, mockCallback)
 
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: `deploys/master`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'app.staging.example.com',
-                    translationHash,
-                    treeHash,
-                    uri: `/html/${treeHash}/index.html`
-                })
-            )
-        )
+        expectAppVersionFetched(s3, 'deploys/master')
+        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`
         When requesting e.g. my-feature.app.staging.example.com
         it modifies the request to fetch the latest HTML for my-feature branch
     `, async () => {
-        const treeHash = '75703e9524292bfa57c259e0621c3ed6b53bfcf2'
-        const translationHash = '123456'
-        const s3 = mockGetObject(treeHash, translationHash)
+        const appVersion = getRandomSha()
+        const s3 = getMockedS3(appVersion)
+        const host = 'my-feature.app.staging.example.com'
+        const event = mockRequestEvent({host})
 
         const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-staging',
-                originBucketRegion: 'eu-west-1',
-                previewDeploymentPostfix: '.app.staging.example.com',
-                isLocalised: 'true'
-            },
+            {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             s3
         )
-        const event = mockRequestEvent({
-            host: 'my-feature.app.staging.example.com',
-            translationHash,
-            treeHash
-        })
+        const request = await handler(event, mockContext, mockCallback)
 
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: `deploys/my-feature`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'my-feature.app.staging.example.com',
-                    translationHash,
-                    treeHash,
-                    uri: `/html/${treeHash}/index.html`
-                })
-            )
-        )
+        expectAppVersionFetched(s3, 'deploys/my-feature')
+        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`Handles requests for specific html files`, async () => {
-        const treeHash = 'ce4a66492551f1cd2fad5296ee94b8ea2667eac3'
-        const translationHash = '123456'
-        const s3 = mockGetObject(treeHash, translationHash)
+        const appVersion = getRandomSha()
+        const s3 = getMockedS3(appVersion)
+        const host = 'my-feature.app.staging.example.com'
+        const event = mockRequestEvent({host, uri: '/iframe.html'})
+
         const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-staging',
-                originBucketRegion: 'eu-west-1',
-                previewDeploymentPostfix: '.app.staging.example.com',
-                isLocalised: 'true'
-            },
+            {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             s3
         )
-        const event = mockRequestEvent({
-            host: 'my-feature.app.staging.example.com',
-            translationHash,
-            treeHash,
-            uri: '/iframe.html'
-        })
+        const request = await handler(event, mockContext, mockCallback)
 
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: `deploys/my-feature`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'my-feature.app.staging.example.com',
-                    translationHash,
-                    treeHash,
-                    uri: `/html/${treeHash}/iframe.html`
-                })
-            )
-        )
+        expectAppVersionFetched(s3, 'deploys/my-feature')
+        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/iframe.html`})
+        expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`Handles requests for well known files`, async () => {
-        const treeHash = 'ce4a66492551f1cd2fad5296ee94b8ea2667eac3'
-        const translationHash = '123456'
-        const s3 = mockGetObject(treeHash, translationHash)
+        const appVersion = getRandomSha()
+        const host = 'my-feature.app.staging.example.com'
+        const s3 = getMockedS3(appVersion)
+        const event = mockRequestEvent({host, uri: '/.well-known/apple-app-site-association'})
+
         const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-staging',
-                originBucketRegion: 'eu-west-1',
-                previewDeploymentPostfix: '.app.staging.example.com',
-                isLocalised: 'true'
-            },
+            {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             s3
         )
-        const event = mockRequestEvent({
-            host: 'my-feature.app.staging.example.com',
-            treeHash,
-            translationHash,
-            uri: '/.well-known/apple-app-site-association'
+        const request = await handler(event, mockContext, mockCallback)
+
+        expectAppVersionFetched(s3, 'deploys/my-feature')
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${appVersion}/.well-known/apple-app-site-association`
         })
-
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: `deploys/my-feature`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'my-feature.app.staging.example.com',
-                    treeHash,
-                    translationHash,
-                    uri: `/html/${treeHash}/.well-known/apple-app-site-association`
-                })
-            )
-        )
+        expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`
-        When requesting a specific version i.e. preview-{treeHash}.app.staging.example.com
+        When requesting a specific version i.e. preview-{appVersion}.app.staging.example.com
         it modifies the request to fetch the HTML for that tree hash
     `, async () => {
-        const treeHash = 'treebe8eaa4f0bb422d1c171769f674c5a1dd1c'
-        const requestedTreeHash = 'reques72715537da0ee129412de8df6bc1287500'
-        const translationHash = '123456'
-        const s3 = new MockedS3()
+        const appVersion = getRandomSha()
+        const requestedAppVersion = getRandomSha()
+        const host = `preview-${requestedAppVersion}.app.staging.example.com`
+        const s3 = getMockedS3(appVersion)
+        const event = mockRequestEvent({host})
 
-        s3.getObject = jest.fn().mockReturnValue({
-            promise: jest.fn().mockReturnValueOnce({Body: translationHash})
-        })
         const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-staging',
-                originBucketRegion: 'eu-west-1',
-                previewDeploymentPostfix: '.app.staging.example.com',
-                isLocalised: 'true'
-            },
+            {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             s3
         )
+        const request = await handler(event, mockContext, mockCallback)
 
-        const event = mockRequestEvent({
-            host: `preview-${requestedTreeHash}.app.staging.example.com`,
-            translationHash,
-            treeHash
+        expect(s3.getObject).not.toHaveBeenCalled()
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${requestedAppVersion}/index.html`
         })
+        expect(request).toEqual(requestFromEvent(expectedEvent))
+    })
 
-        const response = await handler(event, {} as any, () => {})
+    test(`
+        When using the translation addon
+        Then it fetches the translation version from S3
+        And the translation version is set as a header on request
+        And the app version is set as a header on request
+    `, async () => {
+        const appVersion = getRandomSha()
+        const translationVersion = getRandomInt()
+        const host = 'app.example.com'
+        const s3 = getMockedS3(appVersion, translationVersion)
+        const event = mockRequestEvent({host})
 
-        expect(s3.getObject).toHaveBeenCalledTimes(1)
+        const handler = getHandler({...originConfig, isLocalised: 'true'}, s3)
+        const request = await handler(event, mockContext, mockCallback)
 
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: 'translation-deploy/latest'
+        expectVersionsFetched(s3, 'deploys/master', 'translation-deploy/latest')
+        const expectedEvent = mockRequestEvent({
+            host,
+            translationVersion,
+            appVersion,
+            uri: `/html/${appVersion}/index.html`
         })
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: `preview-${requestedTreeHash}.app.staging.example.com`,
-                    translationHash,
-                    treeHash: requestedTreeHash,
-                    uri: `/html/${requestedTreeHash}/index.html`
-                })
-            )
-        )
+        expect(request).toEqual(requestFromEvent(expectedEvent))
+    })
+
+    test(`
+        When fetching the translation version fails
+        Then the translation version header is not set
+        And the app version header is set
+        And the request for the HTML goes through
+    `, async () => {
+        const appVersion = getRandomSha()
+        const host = 'app.example.com'
+        const s3 = getMockedS3(appVersion, new Error('network error, yo'))
+        const event = mockRequestEvent({host})
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+
+        const handler = getHandler({...originConfig, isLocalised: 'true'}, s3)
+        const request = await handler(event, mockContext, mockCallback)
+
+        expectVersionsFetched(s3, 'deploys/master', 'translation-deploy/latest')
+        const expectedEvent = mockRequestEvent({
+            host,
+            translationVersion: undefined,
+            appVersion,
+            uri: `/html/${appVersion}/index.html`
+        })
+        expect(request).toEqual(requestFromEvent(expectedEvent))
+        expect(console.error).toHaveBeenCalledTimes(1)
     })
 
     test(`
         When requesting a preview of an unknown branch,
-        it requests the non-existing file to trigger a 404 error
+        Then it requests the non-existing file to trigger a 404 error
     `, async () => {
-        const treeHash = 'treebe8eaa4f0bb422d1c171769f674c5a1dd1c'
-        const translationHash = '123456'
-        const s3 = new MockedS3()
-        s3.getObject = jest.fn().mockReturnValue({
-            promise: jest
-                .fn()
-                .mockReturnValueOnce(new Error('network error, yo'))
-                .mockReturnValueOnce({Body: translationHash})
-        })
-        jest.spyOn(console, 'error').mockImplementation(() => {})
+        const s3 = getMockedS3(new Error('network error, yo'))
+        const host = 'what-is-this-branch.app.staging.example.com'
+        jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+        const event = mockRequestEvent({host})
 
         const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-staging',
-                originBucketRegion: 'eu-west-1',
-                previewDeploymentPostfix: '.app.staging.example.com',
-                isLocalised: 'true'
-            },
+            {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             s3
         )
-        const event = mockRequestEvent({
-            host: 'what-is-this-branch.app.staging.example.com',
-            treeHash,
-            translationHash
-        })
+        const request = await handler(event, mockContext, mockCallback)
 
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: `deploys/what-is-this-branch`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-staging',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: `what-is-this-branch.app.staging.example.com`,
-                    uri: `/404`,
-                    treeHash,
-                    translationHash
-                })
-            )
-        )
-        expect(console.error).toHaveBeenCalledTimes(1)
-    })
-
-    test(`
-        When receive an error for the request getting translation hash,
-        translation hash value is defauted to the 'default' value
-    `, async () => {
-        const treeHash = 'treebe8eaa4f0bb422d1c171769f674c5a1dd1c'
-        const translationHash = '123456'
-        const s3 = new MockedS3()
-        s3.getObject = jest.fn().mockReturnValue({
-            promise: jest
-                .fn()
-                .mockReturnValueOnce({Body: treeHash})
-                .mockReturnValueOnce(new Error('network error, yo'))
-        })
-        jest.spyOn(console, 'error').mockImplementation(() => {})
-
-        const handler = getHandler(
-            {
-                originBucketName: 'test-origin-bucket-prod',
-                originBucketRegion: 'eu-west-1',
-                isLocalised: 'true'
-            },
-            s3
-        )
-        const event = mockRequestEvent({
-            host: 'app.example.com',
-            translationHash,
-            treeHash
-        })
-
-        const response = await handler(event, {} as any, () => {})
-
-        expect(s3.getObject).toHaveBeenCalledTimes(2)
-
-        expect(s3.getObject).toHaveBeenCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: `deploys/master`
-        })
-
-        expect(s3.getObject).toHaveBeenLastCalledWith({
-            Bucket: 'test-origin-bucket-prod',
-            Key: 'translation-deploy/latest'
-        })
-
-        expect(response).toEqual(
-            requestFromEvent(
-                mockRequestEvent({
-                    host: 'app.example.com',
-                    translationHash,
-                    treeHash,
-                    uri: `/404`
-                })
-            )
-        )
+        expectAppVersionFetched(s3, 'deploys/what-is-this-branch')
+        const expectedEvent = mockRequestEvent({host, uri: `/404`})
+        expect(request).toEqual(requestFromEvent(expectedEvent))
         expect(console.error).toHaveBeenCalledTimes(1)
     })
 })
 
-// const mockGetObject = (returnValue: string) => {
-//     const s3 = new MockedS3()
-//     s3.getObject = jest.fn().mockReturnValue({
-//         promise: jest.fn().mockReturnValue({Body: returnValue})
-//     })
-//     return s3
-// }
-
-const mockGetObject = (firstValue: string, secondValue) => {
+const getMockedS3 = (...values: Array<string | Error>) => {
+    const MockedS3 = S3 as jest.MockedClass<typeof S3>
     const s3 = new MockedS3()
-    s3.getObject = jest.fn().mockReturnValue({
-        promise: jest
-            .fn()
-            .mockReturnValueOnce({Body: firstValue})
-            .mockReturnValueOnce({Body: secondValue})
+    const mockedPromise = jest.fn()
+    values.forEach((value) => {
+        if (value instanceof Error) {
+            mockedPromise.mockReturnValueOnce(value)
+        } else {
+            mockedPromise.mockReturnValueOnce({Body: value})
+        }
     })
+    s3.getObject = jest.fn().mockReturnValue({promise: mockedPromise})
     return s3
 }
 
-// Returns a mock Cloudfront viewer request event with the specified host and URI. See
-// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-viewer-request for
-// more info on the shape of the request events for Edge Lambdas
+/**
+ * Returns a mock Cloudfront viewer request event with the specified host and URI.
+ * For more info on the shape of the request events for Edge Lambdas
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-viewer-request
+ */
 const mockRequestEvent = ({
     host,
-    translationHash,
-    treeHash,
+    translationVersion,
+    appVersion,
     uri = '/'
 }: {
     host: string
-    treeHash?: string
-    translationHash?: string
+    appVersion?: string
+    translationVersion?: string
     uri?: string
 }): CloudFrontRequestEvent => ({
     Records: [
@@ -561,19 +288,19 @@ const mockRequestEvent = ({
                                 value: '*/*'
                             }
                         ],
-                        'x-translation-cursor': translationHash
+                        'x-translation-version': translationVersion
                             ? [
                                   {
-                                      key: 'X-Translation-Cursor',
-                                      value: translationHash
+                                      key: 'X-Translation-Version',
+                                      value: translationVersion
                                   }
                               ]
                             : undefined,
-                        'x-tree-hash': treeHash
+                        'x-app-version': appVersion
                             ? [
                                   {
-                                      key: 'X-Tree-Hash',
-                                      value: treeHash
+                                      key: 'X-App-Version',
+                                      value: appVersion
                                   }
                               ]
                             : undefined
@@ -588,3 +315,25 @@ const mockRequestEvent = ({
 })
 
 const requestFromEvent = (event: CloudFrontRequestEvent) => event.Records[0].cf.request
+const getRandomSha = () => crypto.randomBytes(20).toString('hex')
+const getRandomInt = () => crypto.randomInt(100000, 199999).toString()
+
+function expectAppVersionFetched(s3: S3, key: string) {
+    expect(s3.getObject).toHaveBeenCalledTimes(1)
+    expect(s3.getObject).toHaveBeenCalledWith({
+        Bucket: originConfig.originBucketName,
+        Key: key
+    })
+}
+
+function expectVersionsFetched(s3: S3, appKey: string, translationKey: string) {
+    expect(s3.getObject).toHaveBeenCalledTimes(2)
+    expect(s3.getObject).toHaveBeenCalledWith({
+        Bucket: 'test-origin-bucket',
+        Key: appKey
+    })
+    expect(s3.getObject).toHaveBeenLastCalledWith({
+        Bucket: 'test-origin-bucket',
+        Key: translationKey
+    })
+}

--- a/edge-lambdas/src/viewer-request/viewer-request.test.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.test.ts
@@ -132,7 +132,7 @@ describe(`Viewer request Lambda@Edge`, () => {
 
     test(`
         When requesting a specific version i.e. preview-{appVersion}.app.staging.example.com
-        it modifies the request to fetch the HTML for that tree hash
+        it modifies the request to fetch the HTML for that app version
     `, async () => {
         const appVersion = getRandomSha()
         const requestedAppVersion = getRandomSha()

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -16,9 +16,9 @@ const DEFAULT_BRANCH_DEFAULT_NAME = 'master'
  * This lambda runs for every request and modifies the request object before it's used to fetch the resource from the origin (S3 bucket).
  * It calculates which HTML file the request should respond with based on the host name specified by the request, and sets that file as the URI of the request.
  * The options are:
- * - HTML for latest tree hash on the main branch - e.g. app.staging.pleo.io and app.pleo.io
- * - HTML for latest tree hash on a feature branch (branch preview deployment) - e.g. my-branch.staging.pleo.io
- * - HTML for a specific tree hash (hash preview deployment) - e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.pleo.io
+ * - HTML for latest tree hash on the main branch - e.g. app.staging.example.com and app.example.com
+ * - HTML for latest tree hash on a feature branch (branch preview deployment) - e.g. my-branch.staging.example.com
+ * - HTML for a specific tree hash (hash preview deployment) - e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
  */
 export function getHandler(config: Config, s3: S3) {
     const handler: CloudFrontRequestHandler = async (event) => {
@@ -76,16 +76,11 @@ async function getUri(request: CloudFrontRequest, config: Config, s3: S3) {
 // It can be either a specific tree hash requested via preview link with a hash, or the latest
 // tree hash for a branch requested (preview or main), which we fetch from cursor files stored in S3
 async function getTreeHash(host: string, config: Config, s3: S3) {
-    // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.pleo.io
+    // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
     // Preview name is either a sanitized branch name or it follows the preview-[treeHash] pattern
-    // We only run preview deploys in staging
     let previewName
 
-    if (
-        config.environment === 'staging' &&
-        config.previewDeploymentPostfix &&
-        host.includes(config.previewDeploymentPostfix)
-    ) {
+    if (config.previewDeploymentPostfix && host.includes(config.previewDeploymentPostfix)) {
         previewName = host.split('.')[0]
 
         // If the request is for a specific tree hash preview deployment, we use that hash
@@ -102,7 +97,7 @@ async function getTreeHash(host: string, config: Config, s3: S3) {
     return fetchDeploymentTreeHash(branchName, config, s3)
 }
 
-// We serve a preview for each repo tree hash at e.g.preview-[treeHash].app.staging.pleo.io
+// We serve a preview for each repo tree hash at e.g.preview-[treeHash].app.staging.example.com
 // If the preview name matches that pattern, we assume it's a tree hash preview
 function getPreviewHash(previewName?: string) {
     const matchHash = /^preview-(?<hash>[a-z0-9]{40})$/.exec(previewName || '')

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import {CloudFrontRequest, CloudFrontRequestHandler} from 'aws-lambda'
 import S3 from 'aws-sdk/clients/s3'
 
-import {getHeader, setHeader, TRANSLATION_CURSOR_HEADER} from '../utils'
+import {getHeader, setHeader, TRANSLATION_CURSOR_HEADER, DEFAULT_TRANSLATION_CURSOR} from '../utils'
 import {Config} from '../config'
 
 const DEFAULT_BRANCH_DEFAULT_NAME = 'master'
@@ -42,7 +42,7 @@ export function getHandler(config: Config, s3: S3) {
             )
         } catch (e) {
             console.error(e)
-            console.log(e.message)
+
             if (e.message && e.message.startsWith(URI_PREFIX_ERROR)) {
                 // On failure, we're requesting a non-existent file on purpose, to allow CF to serve
                 // the configured custom error page
@@ -171,6 +171,6 @@ const getTranslationCursor = async (s3: S3, config: Config) => {
         )
         return response
     } catch (e) {
-        return 'default'
+        return DEFAULT_TRANSLATION_CURSOR
     }
 }

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import {CloudFrontRequest, CloudFrontRequestHandler} from 'aws-lambda'
 import S3 from 'aws-sdk/clients/s3'
 
-import {getHeader} from '../utils'
+import {getHeader, setHeader, TRANSLATION_CURSOR_HEADER} from '../utils'
 import {Config} from '../config'
 
 const DEFAULT_BRANCH_DEFAULT_NAME = 'master'
@@ -16,9 +16,9 @@ const DEFAULT_BRANCH_DEFAULT_NAME = 'master'
  * This lambda runs for every request and modifies the request object before it's used to fetch the resource from the origin (S3 bucket).
  * It calculates which HTML file the request should respond with based on the host name specified by the request, and sets that file as the URI of the request.
  * The options are:
- * - HTML for latest tree hash on the main branch - e.g. app.staging.example.com and app.example.com
- * - HTML for latest tree hash on a feature branch (branch preview deployment) - e.g. my-branch.staging.example.com
- * - HTML for a specific tree hash (hash preview deployment) - e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
+ * - HTML for latest tree hash on the main branch - e.g. app.staging.pleo.io and app.pleo.io
+ * - HTML for latest tree hash on a feature branch (branch preview deployment) - e.g. my-branch.staging.pleo.io
+ * - HTML for a specific tree hash (hash preview deployment) - e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.pleo.io
  */
 export function getHandler(config: Config, s3: S3) {
     const handler: CloudFrontRequestHandler = async (event) => {
@@ -32,6 +32,15 @@ export function getHandler(config: Config, s3: S3) {
             // On failure, we're requesting a non-existent file on purpose, to allow CF to serve
             // the configured custom error page
             request.uri = '/404'
+        }
+
+        try {
+            let headers = request.headers
+            const translationCursor = await getTranslationCursor(s3, config)
+            headers = setHeader(headers, TRANSLATION_CURSOR_HEADER, translationCursor)
+            request.headers = headers
+        } catch (e) {
+            console.error(e)
         }
 
         return request
@@ -67,11 +76,16 @@ async function getUri(request: CloudFrontRequest, config: Config, s3: S3) {
 // It can be either a specific tree hash requested via preview link with a hash, or the latest
 // tree hash for a branch requested (preview or main), which we fetch from cursor files stored in S3
 async function getTreeHash(host: string, config: Config, s3: S3) {
-    // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
+    // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.pleo.io
     // Preview name is either a sanitized branch name or it follows the preview-[treeHash] pattern
+    // We only run preview deploys in staging
     let previewName
 
-    if (config.previewDeploymentPostfix && host.includes(config.previewDeploymentPostfix)) {
+    if (
+        config.environment === 'staging' &&
+        config.previewDeploymentPostfix &&
+        host.includes(config.previewDeploymentPostfix)
+    ) {
         previewName = host.split('.')[0]
 
         // If the request is for a specific tree hash preview deployment, we use that hash
@@ -88,7 +102,7 @@ async function getTreeHash(host: string, config: Config, s3: S3) {
     return fetchDeploymentTreeHash(branchName, config, s3)
 }
 
-// We serve a preview for each repo tree hash at e.g.preview-[treeHash].app.staging.example.com
+// We serve a preview for each repo tree hash at e.g.preview-[treeHash].app.staging.pleo.io
 // If the preview name matches that pattern, we assume it's a tree hash preview
 function getPreviewHash(previewName?: string) {
     const matchHash = /^preview-(?<hash>[a-z0-9]{40})$/.exec(previewName || '')
@@ -110,4 +124,22 @@ async function fetchDeploymentTreeHash(branch: string, config: Config, s3: S3) {
     }
 
     return response.Body.toString('utf-8').trim()
+}
+
+const getTranslationCursor = async (s3: S3, config: Config) => {
+    try {
+        const s3Params = {
+            Bucket: config.originBucketName,
+            Key: `translation-deploy/latest`
+        }
+        const response = await s3.getObject(s3Params).promise()
+
+        if (!response.Body) {
+            throw new Error(`Latest cursor file not found `)
+        }
+
+        return response.Body.toString('utf-8').trim()
+    } catch (e) {
+        return 'default'
+    }
 }

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -163,6 +163,7 @@ async function fetchDeploymentTreeHash(branch: string, config: Config, s3: S3) {
         config,
         s3
     )
+    console.log('fetchDeploymentTreeHash', response)
     return response
 }
 
@@ -177,6 +178,7 @@ export const fetchDeploymentTranslationHash = async (s3: S3, config: Config) => 
             config,
             s3
         )
+        console.log('fetchDeploymentTranslationHash', response)
         return response
     } catch (e) {
         return DEFAULT_TRANSLATION_CURSOR

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -3,54 +3,53 @@ import * as path from 'path'
 import {CloudFrontRequest, CloudFrontRequestHandler} from 'aws-lambda'
 import S3 from 'aws-sdk/clients/s3'
 
-import {getHeader, setHeader, TRANSLATION_CURSOR_HEADER, TREE_HASH_HEADER} from '../utils'
+import {fetchFileFromS3Bucket, getHeader} from '../utils'
 import {Config} from '../config'
+import {addTranslationInfoToRequest, getTranslationVersion} from '../addons/translations'
 
 const DEFAULT_BRANCH_DEFAULT_NAME = 'master'
 
 /**
- * Edge Lambda handler triggered on "viewer-request" event, on the default CF behavior of the web app CF distribution.
- * The default CF behaviour only handles requests for HTML documents and requests for static files (e.g. /, /bills, /settings/accounting etc.)
- * Since our app is client side routed, all these requests return the same HTML index file.
+ * Edge Lambda handler triggered on "viewer-request" event, on the default CF behavior of the web app
+ * CF distribution. The default CF behavior only handles requests for HTML documents and requests for
+ * static files (e.g. /, /bills, /settings/accounting etc.). Since our app is client side routed, all
+ * these requests return the same HTML index file.
  *
- * This lambda runs for every request and modifies the request object before it's used to fetch the resource from the origin (S3 bucket).
- * It calculates which HTML file the request should respond with based on the host name specified by the request, and sets that file as the URI of the request.
+ * This lambda runs for every request and modifies the request object before it's used to fetch the
+ * resource from the origin (S3 bucket). It calculates which HTML file the request should respond with
+ * based on the host name specified by the request, and sets that file as the URI of the request.
  * The options are:
- * - HTML for latest tree hash on the main branch - e.g. app.staging.example.com and app.example.com
- * - HTML for latest tree hash on a feature branch (branch preview deployment) - e.g. my-branch.staging.example.com
- * - HTML for a specific tree hash (hash preview deployment) - e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
+ * - HTML for latest app version on the main branch
+ *   e.g. app.staging.example.com and app.example.com
+ * - HTML for latest app version on a feature branch (branch preview deployment)
+ *   e.g. my-branch.staging.example.com
+ * - HTML for a specific app version (hash preview deployment)
+ *   e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
+ *
+ * If the translations are enabled via configuration, this lambda will also fetch the current translation
+ * version from S3 and pass it to the response lambda via custom headers on the request object.
  */
 export function getHandler(config: Config, s3: S3) {
     const handler: CloudFrontRequestHandler = async (event) => {
         const request = event.Records[0].cf.request
 
         try {
-            // Get tree hash and translation cursor in parralel to avoid the double network penalty
-            const [treeHash, translationCursor] = await Promise.all(
-                [
-                    getTreeHash(request, config, s3),
-                    config.isLocalised === 'true'
-                        ? fetchDeploymentTranslationHash(s3, config)
-                        : undefined
-                ].filter((val) => Boolean(val))
-            )
+            // Get app version and translation version in parallel to avoid the double network penalty.
+            // Translation hash is only fetched if translations are enabled. Fetching translation cursor
+            // can never throw here, as in case of a failure we're returning a default value.
+            const [appVersion, translationVersion] = await Promise.all([
+                getAppVersion(request, config, s3),
+                getTranslationVersion(s3, config)
+            ])
 
-            const uri = getUri(request, treeHash)
+            // If needed, pass the versions to the viewer response lambda via custom headers on the request
+            addTranslationInfoToRequest({request, translationVersion, appVersion, config})
 
-            // We instruct the CDN to return a file that corresponds to the tree hash requested
+            // We instruct the CDN to return a file that corresponds to the app version calculated
+            const uri = getUri(request, appVersion)
             request.uri = uri
-
-            if (config.isLocalised === 'true') {
-                request.headers = setHeader(
-                    request.headers,
-                    TRANSLATION_CURSOR_HEADER,
-                    translationCursor
-                )
-
-                request.headers = setHeader(request.headers, TREE_HASH_HEADER, treeHash)
-            }
-        } catch (e) {
-            console.error(e)
+        } catch (error) {
+            console.error(error)
             // On failure, we're requesting a non-existent file on purpose, to allow CF to serve
             // the configured custom error page
             request.uri = '/404'
@@ -62,7 +61,9 @@ export function getHandler(config: Config, s3: S3) {
     return handler
 }
 
-// We respond with a requested file, but prefix it with the hash of the current active deployment
+/**
+ * We respond with a requested file, but prefix it with the hash of the current active deployment
+ */
 function getUri(request: CloudFrontRequest, treeHash: string) {
     // If the
     // - request uri is for a specific file (e.g. "/iframe.html")
@@ -77,24 +78,22 @@ function getUri(request: CloudFrontRequest, treeHash: string) {
     return path.join('/html', treeHash, filePath)
 }
 
-// We use repository tree hash to identify the version of the HTML served.
-// It can be either a specific tree hash requested via preview link with a hash, or the latest
-// tree hash for a branch requested (preview or main), which we fetch from cursor files stored in S3
-async function getTreeHash(request: CloudFrontRequest, config: Config, s3: S3) {
-    const host = getHeader(request, 'host')
-
-    if (!host) {
-        throw new Error('Missing Host header')
-    }
+/**
+ * Calculate the version of the app that should be served.
+ * It can be either a specific version requested via preview link with a hash, or the latest
+ * version for a branch requested (preview or main), which we fetch from cursor files stored in S3
+ */
+async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3) {
+    const host = getHeader(request, 'host') ?? null
 
     // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
-    // Preview name is either a sanitized branch name or it follows the preview-[treeHash] pattern
-    let previewName
+    // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
+    let previewName: string
 
-    if (config.previewDeploymentPostfix && host.includes(config.previewDeploymentPostfix)) {
+    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix)) {
         previewName = host.split('.')[0]
 
-        // If the request is for a specific tree hash preview deployment, we use that hash
+        // If the request is for a specific hash of a preview deployment, we use that hash
         const previewHash = getPreviewHash(previewName)
         if (previewHash) {
             return previewHash
@@ -103,58 +102,28 @@ async function getTreeHash(request: CloudFrontRequest, config: Config, s3: S3) {
 
     const defaultBranchName = config.defaultBranchName ?? DEFAULT_BRANCH_DEFAULT_NAME
 
-    // Otherwise we fetch the current tree hash for requested branch from S3
+    // Otherwise we fetch the current app version for requested branch from S3
     const branchName = previewName || defaultBranchName
-    return fetchDeploymentTreeHash(branchName, config, s3)
+    return fetchAppVersion(branchName, config, s3)
 }
 
-// We serve a preview for each repo tree hash at e.g.preview-[treeHash].app.staging.example.com
-// If the preview name matches that pattern, we assume it's a tree hash preview
+/**
+ * We serve a preview for each app version at e.g.preview-[hash].app.staging.example.com
+ * If the preview name matches that pattern, we assume it's a hash preview link
+ */
 function getPreviewHash(previewName?: string) {
     const matchHash = /^preview-(?<hash>[a-z0-9]{40})$/.exec(previewName || '')
     return matchHash?.groups?.hash
 }
 
 /**
- * Fetches a file from the S3 origin bucket and returns its content
- * @param key key for the S3 bucket
- * @param onEmpty function will be called if file doesn't exist
- * @param config config object
- * @param s3 S3 instance
- * @returns content of the file
+ * Fetch a cursor deploy file from the S3 bucket and returns its content, which is the current
+ * active app version for that branch).
  */
-async function fetchFileFromOriginBucket(key: string, config: Config, s3: S3) {
-    const s3Params = {
-        Bucket: config.originBucketName,
-        Key: key
-    }
-    const response = await s3.getObject(s3Params).promise()
-    if (!response.Body) {
-        throw new Error()
-    }
-
-    return response.Body.toString('utf-8').trim()
-}
-
-/**
- * Fetches a cursor deploy file from the S3 bucket and returns its content (i.e. the current active tree hash
- * for that branch).
- */
-async function fetchDeploymentTreeHash(branch: string, config: Config, s3: S3) {
+async function fetchAppVersion(branch: string, config: Config, s3: S3) {
     try {
-        const response = await fetchFileFromOriginBucket(`deploys/${branch}`, config, s3)
-        return response
-    } catch {
+        return await fetchFileFromS3Bucket(`deploys/${branch}`, config.originBucketName, s3)
+    } catch (error) {
         throw new Error(`Cursor file not found for branch=${branch}`)
-    }
-}
-
-// Get the latest translation cursor file from S3 bucket
-export const fetchDeploymentTranslationHash = async (s3: S3, config: Config) => {
-    try {
-        const response = await fetchFileFromOriginBucket(`translation-deploy/latest`, config, s3)
-        return response
-    } catch {
-        throw new Error(`Latest translation cursor file not found`)
     }
 }

--- a/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -64,7 +64,7 @@ export function getHandler(config: Config, s3: S3) {
 /**
  * We respond with a requested file, but prefix it with the hash of the current active deployment
  */
-function getUri(request: CloudFrontRequest, treeHash: string) {
+function getUri(request: CloudFrontRequest, appVersion: string) {
     // If the
     // - request uri is for a specific file (e.g. "/iframe.html")
     // - or is a request on one of the .well-known paths (like .well-known/apple-app-site-association)
@@ -75,7 +75,7 @@ function getUri(request: CloudFrontRequest, treeHash: string) {
     const isWellKnownRequest = request.uri.startsWith('/.well-known/')
     const filePath = isFileRequest || isWellKnownRequest ? request.uri : '/index.html'
 
-    return path.join('/html', treeHash, filePath)
+    return path.join('/html', appVersion, filePath)
 }
 
 /**

--- a/edge-lambdas/src/viewer-response/viewer-response.test.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.test.ts
@@ -5,7 +5,8 @@ describe(`Viewer response Lambda@Edge`, () => {
     test(`Adds security and cache control custom headers to a response object for prod`, async () => {
         const handler = getHandler({
             originBucketName: 'test-cursor-bucket-prod',
-            originBucketRegion: 'eu-west-1'
+            originBucketRegion: 'eu-west-1',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.example.com'})
@@ -26,7 +27,8 @@ describe(`Viewer response Lambda@Edge`, () => {
             originBucketName: 'test-origin-bucket-staging',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.staging.example.com',
-            blockRobots: 'true'
+            blockRobots: 'true',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.staging.example.com'})
@@ -49,7 +51,8 @@ describe(`Viewer response Lambda@Edge`, () => {
             originBucketName: 'test-origin-bucket',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true'
+            blockIframes: 'true',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.staging.example.com'})
@@ -73,7 +76,8 @@ describe(`Viewer response Lambda@Edge`, () => {
             originBucketName: 'test-origin-bucket',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true'
+            blockIframes: 'true',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.staging.example.com', hash})
@@ -91,6 +95,29 @@ describe(`Viewer response Lambda@Edge`, () => {
         })
     })
 
+    test(`No preload headers and no update hash value for 'translation-hash' cookie when isLocalised='false'`, async () => {
+        const handler = getHandler({
+            originBucketName: 'test-origin-bucket',
+            originBucketRegion: 'eu-west-1',
+            previewDeploymentPostfix: '.app.example.com',
+            blockIframes: 'true',
+            isLocalised: 'false'
+        })
+
+        const event = mockResponseEvent({host: 'app.staging.example.com'})
+
+        expect(await handler(event, {} as any, () => {})).toEqual({
+            headers: {
+                ...securityHeaders,
+                'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
+                ...defaultHeaders,
+                ...cacheControlHeaders
+            },
+            status: '200',
+            statusDescription: 'OK'
+        })
+    })
+
     test(`Add preload headers and update hash value from tree hash for en instead of 'translation-hash'`, async () => {
         const hash = '123123'
         const translationHash = '456456'
@@ -98,7 +125,8 @@ describe(`Viewer response Lambda@Edge`, () => {
             originBucketName: 'test-origin-bucket',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true'
+            blockIframes: 'true',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.staging.example.com', hash, translationHash})
@@ -122,7 +150,8 @@ describe(`Viewer response Lambda@Edge`, () => {
             originBucketName: 'test-origin-bucket',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true'
+            blockIframes: 'true',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({host: 'app.staging.example.com', hash, language: 'da'})
@@ -146,7 +175,8 @@ describe(`Viewer response Lambda@Edge`, () => {
             originBucketName: 'test-origin-bucket',
             originBucketRegion: 'eu-west-1',
             previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true'
+            blockIframes: 'true',
+            isLocalised: 'true'
         })
 
         const event = mockResponseEvent({

--- a/edge-lambdas/src/viewer-response/viewer-response.test.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.test.ts
@@ -109,7 +109,7 @@ describe(`Viewer response Lambda@Edge`, () => {
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
                 ...defaultHeaders,
                 ...cacheControlHeaders,
-                ...getHeaderBasedOnHash(translationHash, hash)
+                ...getHeaderBasedOnHash(hash, translationHash)
             },
             status: '200',
             statusDescription: 'OK'
@@ -190,11 +190,7 @@ const cacheControlHeaders = {
     ]
 }
 
-const getHeaderBasedOnHash = (
-    translationHash = 'default',
-    hash = translationHash,
-    language = 'en'
-) => {
+const getHeaderBasedOnHash = (hash = undefined, translationHash = hash, language = 'en') => {
     return {
         'set-cookie': [
             {
@@ -202,15 +198,14 @@ const getHeaderBasedOnHash = (
                 value: `translation-hash=${translationHash}`
             }
         ],
-        link:
-            hash !== 'default'
-                ? [
-                      {
-                          key: 'Link',
-                          value: `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`
-                      }
-                  ]
-                : undefined
+        link: Boolean(hash)
+            ? [
+                  {
+                      key: 'Link',
+                      value: `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`
+                  }
+              ]
+            : undefined
     }
 }
 
@@ -219,7 +214,7 @@ const getHeaderBasedOnHash = (
 // more info on the shape of the response events for Edge Lambdas
 export const mockResponseEvent = ({
     host,
-    hash = 'default',
+    hash,
     translationHash = hash,
     uri = '/',
     language,

--- a/edge-lambdas/src/viewer-response/viewer-response.test.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.test.ts
@@ -1,44 +1,54 @@
+import crypto from 'crypto'
 import {CloudFrontResponseEvent} from 'aws-lambda'
 import {getHandler} from './viewer-response'
 
-describe(`Viewer response Lambda@Edge`, () => {
-    test(`Adds security and cache control custom headers to a response object for prod`, async () => {
-        const handler = getHandler({
-            originBucketName: 'test-cursor-bucket-prod',
-            originBucketRegion: 'eu-west-1',
-            isLocalised: 'true'
-        })
+const originConfig = {
+    originBucketName: 'test-cursor-bucket',
+    originBucketRegion: 'eu-west-1'
+}
+const mockContext = {} as any
+const mockCallback = () => {}
 
+describe(`Viewer response Lambda@Edge`, () => {
+    test(`
+        When processing a response for the default branch
+        Then it adds security custom header to the response
+        And it adds cache control custom header to the response
+    `, async () => {
         const event = mockResponseEvent({host: 'app.example.com'})
-        expect(await handler(event, {} as any, () => {})).toEqual({
+
+        const handler = getHandler(originConfig)
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
             headers: {
                 ...securityHeaders,
                 ...cacheControlHeaders,
-                ...defaultHeaders,
-                ...getHeaderBasedOnHash()
+                ...defaultHeaders
             },
             status: '200',
             statusDescription: 'OK'
         })
     })
 
-    test(`Adds robots custom headers to a response object if configured`, async () => {
-        const handler = getHandler({
-            originBucketName: 'test-origin-bucket-staging',
-            originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.staging.example.com',
-            blockRobots: 'true',
-            isLocalised: 'true'
-        })
-
+    test(`
+        When blocking robots is turned on
+        Then it adds robots custom header to the response
+    `, async () => {
         const event = mockResponseEvent({host: 'app.staging.example.com'})
 
-        expect(await handler(event, {} as any, () => {})).toEqual({
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.staging.example.com',
+            blockRobots: 'true'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
             headers: {
                 ...securityHeaders,
                 ...defaultHeaders,
                 ...cacheControlHeaders,
-                ...getHeaderBasedOnHash(),
                 'x-robots-tag': [{key: 'X-Robots-Tag', value: 'noindex, nofollow'}]
             },
             status: '200',
@@ -46,67 +56,20 @@ describe(`Viewer response Lambda@Edge`, () => {
         })
     })
 
-    test(`Adds security with frame blocking custom header to a response if configured`, async () => {
-        const handler = getHandler({
-            originBucketName: 'test-origin-bucket',
-            originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true',
-            isLocalised: 'true'
-        })
-
+    test(`
+        When blocking iFrames is turned on
+        Then it adds frame blocking custom header to the response
+    `, async () => {
         const event = mockResponseEvent({host: 'app.staging.example.com'})
 
-        expect(await handler(event, {} as any, () => {})).toEqual({
-            headers: {
-                ...securityHeaders,
-                'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
-                ...cacheControlHeaders,
-                ...getHeaderBasedOnHash()
-            },
-            status: '200',
-            statusDescription: 'OK'
-        })
-    })
-
-    test(`Add preload headers and update hash value for 'translation-hash' cookie`, async () => {
-        const hash = '123123'
         const handler = getHandler({
-            originBucketName: 'test-origin-bucket',
-            originBucketRegion: 'eu-west-1',
+            ...originConfig,
             previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true',
-            isLocalised: 'true'
+            blockIframes: 'true'
         })
+        const response = await handler(event, mockContext, mockCallback)
 
-        const event = mockResponseEvent({host: 'app.staging.example.com', hash})
-
-        expect(await handler(event, {} as any, () => {})).toEqual({
-            headers: {
-                ...securityHeaders,
-                'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
-                ...cacheControlHeaders,
-                ...getHeaderBasedOnHash(hash)
-            },
-            status: '200',
-            statusDescription: 'OK'
-        })
-    })
-
-    test(`No preload headers and no update hash value for 'translation-hash' cookie when isLocalised='false'`, async () => {
-        const handler = getHandler({
-            originBucketName: 'test-origin-bucket',
-            originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true',
-            isLocalised: 'false'
-        })
-
-        const event = mockResponseEvent({host: 'app.staging.example.com'})
-
-        expect(await handler(event, {} as any, () => {})).toEqual({
+        expect(response).toEqual({
             headers: {
                 ...securityHeaders,
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
@@ -118,81 +81,210 @@ describe(`Viewer response Lambda@Edge`, () => {
         })
     })
 
-    test(`Add preload headers and update hash value from tree hash for en instead of 'translation-hash'`, async () => {
-        const hash = '123123'
-        const translationHash = '456456'
-        const handler = getHandler({
-            originBucketName: 'test-origin-bucket',
-            originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true',
-            isLocalised: 'true'
-        })
-
-        const event = mockResponseEvent({host: 'app.staging.example.com', hash, translationHash})
-
-        expect(await handler(event, {} as any, () => {})).toEqual({
-            headers: {
-                ...securityHeaders,
-                'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
-                ...cacheControlHeaders,
-                ...getHeaderBasedOnHash(hash, translationHash)
-            },
-            status: '200',
-            statusDescription: 'OK'
-        })
-    })
-
-    test(`Add preload headers and update hash value for 'translation-hash' cookie with da language from cookie 'x-pleo-language'`, async () => {
-        const hash = '123123'
-        const handler = getHandler({
-            originBucketName: 'test-origin-bucket',
-            originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true',
-            isLocalised: 'true'
-        })
-
-        const event = mockResponseEvent({host: 'app.staging.example.com', hash, language: 'da'})
-
-        expect(await handler(event, {} as any, () => {})).toEqual({
-            headers: {
-                ...securityHeaders,
-                'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
-                ...cacheControlHeaders,
-                ...getHeaderBasedOnHash(hash, hash, 'da')
-            },
-            status: '200',
-            statusDescription: 'OK'
-        })
-    })
-
-    test(`Add preload headers and update hash value for 'translation-hash' cookie with da language from url param 'lang'`, async () => {
-        const hash = '123123'
-        const handler = getHandler({
-            originBucketName: 'test-origin-bucket',
-            originBucketRegion: 'eu-west-1',
-            previewDeploymentPostfix: '.app.example.com',
-            blockIframes: 'true',
-            isLocalised: 'true'
-        })
-
+    test(`
+        When the translations addon is on
+        And there is no language cookie or param
+        Then it adds a preload header using the app version and default language
+        And it adds a translation cookie using the translation version
+    `, async () => {
+        const appVersion = getRandomSha()
+        const translationVersion = getRandomInt()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            hash,
-            language: 'da',
-            isCookieForLanguage: false
+            translations: {appVersion, translationVersion}
         })
 
-        expect(await handler(event, {} as any, () => {})).toEqual({
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.example.com',
+            isLocalised: 'true'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
+            headers: {
+                ...securityHeaders,
+                ...defaultHeaders,
+                ...cacheControlHeaders,
+                ...getTranslationHeaders({
+                    cookieHash: translationVersion,
+                    preloadHash: appVersion,
+                    language: 'en'
+                })
+            },
+            status: '200',
+            statusDescription: 'OK'
+        })
+    })
+
+    test(`
+        When the translation module is off
+        Then it does not add a preload header 
+        And it does not add a translation cookie
+    `, async () => {
+        const event = mockResponseEvent({host: 'app.staging.example.com'})
+
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.example.com',
+            isLocalised: 'false'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
+            headers: {
+                ...securityHeaders,
+                ...defaultHeaders,
+                ...cacheControlHeaders
+            },
+            status: '200',
+            statusDescription: 'OK'
+        })
+    })
+
+    test(`
+        When a custom language is set via a cookie
+        Then it adds a preload header using the translation version
+        And the custom language is used for the preload header
+        And it adds a translation cookie using the translation version
+    `, async () => {
+        const appVersion = getRandomSha()
+        const translationVersion = getRandomInt()
+        const event = mockResponseEvent({
+            host: 'app.staging.example.com',
+            translations: {appVersion, translationVersion},
+            languageForCookie: 'da'
+        })
+
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.example.com',
+            isLocalised: 'true'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
+            headers: {
+                ...securityHeaders,
+                ...defaultHeaders,
+                ...cacheControlHeaders,
+                ...getTranslationHeaders({
+                    cookieHash: translationVersion,
+                    preloadHash: translationVersion,
+                    language: 'da'
+                })
+            },
+            status: '200',
+            statusDescription: 'OK'
+        })
+    })
+
+    test(`
+        When a default language is set via a cookie
+        Then it adds a preload header using the app version
+        And it adds a translation cookie using the translation version
+    `, async () => {
+        const appVersion = getRandomSha()
+        const translationVersion = getRandomInt()
+        const event = mockResponseEvent({
+            host: 'app.staging.example.com',
+            translations: {appVersion, translationVersion},
+            languageForCookie: 'en'
+        })
+
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.example.com',
+            isLocalised: 'true'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
+            headers: {
+                ...securityHeaders,
+                ...defaultHeaders,
+                ...cacheControlHeaders,
+                ...getTranslationHeaders({
+                    cookieHash: translationVersion,
+                    preloadHash: appVersion,
+                    language: 'en'
+                })
+            },
+            status: '200',
+            statusDescription: 'OK'
+        })
+    })
+
+    test(`
+        When a custom language is selected via a query parameter
+        Then it adds a preload header for that language
+    `, async () => {
+        const appVersion = getRandomSha()
+        const translationVersion = getRandomInt()
+        const event = mockResponseEvent({
+            host: 'app.staging.example.com',
+            translations: {appVersion, translationVersion},
+            languageForParam: 'da'
+        })
+
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.example.com',
+            blockIframes: 'true',
+            isLocalised: 'true'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
             headers: {
                 ...securityHeaders,
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
                 ...defaultHeaders,
                 ...cacheControlHeaders,
-                ...getHeaderBasedOnHash(hash, hash, 'da')
+                ...getTranslationHeaders({
+                    cookieHash: translationVersion,
+                    preloadHash: translationVersion,
+                    language: 'da'
+                })
+            },
+            status: '200',
+            statusDescription: 'OK'
+        })
+    })
+
+    test(`
+        When a custom language is selected via a query parameter
+        And a custom language is selected via a cookie
+        Then it adds a preload header for the query param language
+    `, async () => {
+        const appVersion = getRandomSha()
+        const translationVersion = getRandomInt()
+        const event = mockResponseEvent({
+            host: 'app.staging.example.com',
+            translations: {appVersion, translationVersion},
+            languageForParam: 'da',
+            languageForCookie: 'fr'
+        })
+
+        const handler = getHandler({
+            ...originConfig,
+            previewDeploymentPostfix: '.app.example.com',
+            blockIframes: 'true',
+            isLocalised: 'true'
+        })
+        const response = await handler(event, mockContext, mockCallback)
+
+        expect(response).toEqual({
+            headers: {
+                ...securityHeaders,
+                'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
+                ...defaultHeaders,
+                ...cacheControlHeaders,
+                ...getTranslationHeaders({
+                    cookieHash: translationVersion,
+                    preloadHash: translationVersion,
+                    language: 'da'
+                })
             },
             status: '200',
             statusDescription: 'OK'
@@ -220,42 +312,53 @@ const cacheControlHeaders = {
     ]
 }
 
-const getHeaderBasedOnHash = (hash = undefined, translationHash = hash, language = 'en') => {
+const getTranslationHeaders = ({
+    cookieHash,
+    preloadHash,
+    language
+}: {
+    cookieHash: string
+    preloadHash: string
+    language: string
+}) => {
     return {
         'set-cookie': [
             {
                 key: 'Set-Cookie',
-                value: `translation-hash=${translationHash}`
+                value: `translation-version=${cookieHash}`
             }
         ],
-        link: Boolean(hash)
+        link: Boolean(preloadHash)
             ? [
                   {
                       key: 'Link',
-                      value: `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`
+                      value: `</static/translations/${language}/messages.${preloadHash}.js>; rel="preload"; as="script"`
                   }
               ]
             : undefined
     }
 }
 
-// Returns a mock Cloudfront viewer response event with the specified host and URI. See
-// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#lambda-event-structure-response-viewer for
-// more info on the shape of the response events for Edge Lambdas
+/**
+ * Returns a mock Cloudfront viewer response event with the specified host and URI
+ * For more info on the shape of the response events for Edge Lambdas
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#lambda-event-structure-response-viewer
+ */
 export const mockResponseEvent = ({
     host,
-    hash,
-    translationHash = hash,
+    translations,
     uri = '/',
-    language,
-    isCookieForLanguage = true
+    languageForCookie,
+    languageForParam
 }: {
     host: string
-    hash?: string
-    translationHash?: string
+    translations?: {
+        appVersion: string
+        translationVersion?: string
+    }
     uri?: string
-    language?: string
-    isCookieForLanguage?: boolean
+    languageForCookie?: string
+    languageForParam?: string
 }): CloudFrontResponseEvent => ({
     Records: [
         {
@@ -275,29 +378,32 @@ export const mockResponseEvent = ({
                                 value: host
                             }
                         ],
-                        'x-translation-cursor': [
-                            {
-                                key: 'X-Translation-Cursor',
-                                value: translationHash
-                            }
-                        ],
-                        'x-tree-hash': [
-                            {
-                                key: 'X-Translation-Cursor',
-                                value: hash
-                            }
-                        ],
-                        cookie:
-                            language && isCookieForLanguage
-                                ? [
+                        ...(translations
+                            ? {
+                                  'x-translation-version': [
                                       {
-                                          key: 'Cookie',
-                                          value: `x-pleo-language=${language}`
+                                          key: 'X-Translation-Version',
+                                          value: translations.translationVersion
+                                      }
+                                  ],
+                                  'x-app-version': [
+                                      {
+                                          key: 'X-App-Version',
+                                          value: translations.appVersion
                                       }
                                   ]
-                                : undefined
+                              }
+                            : {}),
+                        cookie: languageForCookie
+                            ? [
+                                  {
+                                      key: 'Cookie',
+                                      value: `x-pleo-language=${languageForCookie}`
+                                  }
+                              ]
+                            : undefined
                     },
-                    querystring: language && !isCookieForLanguage ? `?lang=${language}` : '',
+                    querystring: languageForParam ? `?lang=${languageForParam}` : '',
                     clientIp: '203.0.113.178',
                     method: 'GET'
                 },
@@ -310,3 +416,6 @@ export const mockResponseEvent = ({
         }
     ]
 })
+
+const getRandomSha = () => crypto.randomBytes(20).toString('hex')
+const getRandomInt = () => crypto.randomInt(100000, 199999).toString()

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -21,10 +21,7 @@ export function getHandler(config: Config) {
         let response = event.Records[0].cf.response
         const request = event.Records[0].cf.request
 
-        console.log('response', response)
-        console.log('request', request)
         const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER) || 'default'
-        console.log('translationCursor', translationCursor)
 
         response = addSecurityHeaders(response, config)
         response = addCacheHeader(response)
@@ -78,7 +75,7 @@ export const addCacheHeader = (response: CloudFrontResponse) => {
 export const addRobotsHeader = (response: CloudFrontResponse, config: Config) => {
     let headers = response.headers
 
-    if (config.environment === 'staging') {
+    if (config.blockRobots === 'true') {
         headers = setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow')
     }
 
@@ -107,7 +104,7 @@ export const addPreloadHeaders = (
     let headers = response.headers
     const urlParams = new URLSearchParams(request.querystring)
     const language = urlParams.get('lang') || extractCookie(request.headers, 'x-pleo-language')
-    console.log('language', language)
+
     headers = setHeader(
         headers,
         'Link',
@@ -120,7 +117,7 @@ export const addPreloadHeaders = (
 const extractCookie = (headers: CloudFrontHeaders, cname: string) => {
     const cookies = headers['cookie']
     if (!cookies) {
-        console.log("extract_cookie(): no 'Cookie:' headers in request")
+        console.log("extractCookie(): no 'Cookie:' headers in request")
         return null
     }
 

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -9,7 +9,6 @@ import {
     setHeader,
     getHeader,
     TRANSLATION_CURSOR_HEADER,
-    DEFAULT_TRANSLATION_CURSOR,
     TREE_HASH_HEADER,
     getCookie
 } from '../utils'
@@ -28,8 +27,7 @@ export function getHandler(config: Config) {
         let response = event.Records[0].cf.response
         const request = event.Records[0].cf.request
 
-        const translationCursor =
-            getHeader(request, TRANSLATION_CURSOR_HEADER) || DEFAULT_TRANSLATION_CURSOR
+        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER)
 
         const treeHash = getHeader(request, TREE_HASH_HEADER)
 
@@ -37,7 +35,7 @@ export function getHandler(config: Config) {
         response = addCacheHeader(response)
         response = addRobotsHeader(response, config)
         response = setTranslationHashCookie(response, translationCursor)
-        if (translationCursor !== DEFAULT_TRANSLATION_CURSOR) {
+        if (Boolean(translationCursor)) {
             response = addPreloadHeader(response, request, translationCursor, treeHash)
         }
 

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -1,6 +1,11 @@
-import {CloudFrontResponse, CloudFrontResponseHandler} from 'aws-lambda'
+import {
+    CloudFrontResponse,
+    CloudFrontResponseHandler,
+    CloudFrontHeaders,
+    CloudFrontRequest
+} from 'aws-lambda'
 import {Config} from '../config'
-import {setHeader} from '../utils'
+import {setHeader, getHeader, TRANSLATION_CURSOR_HEADER} from '../utils'
 
 /**
  * Edge Lambda handler triggered on "viewer-response" event, on the default CF behavior of the web app CF distribution.
@@ -14,10 +19,18 @@ import {setHeader} from '../utils'
 export function getHandler(config: Config) {
     const handler: CloudFrontResponseHandler = async (event) => {
         let response = event.Records[0].cf.response
+        const request = event.Records[0].cf.request
+
+        console.log('response', response)
+        console.log('request', request)
+        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER) || 'default'
+        console.log('translationCursor', translationCursor)
 
         response = addSecurityHeaders(response, config)
         response = addCacheHeader(response)
         response = addRobotsHeader(response, config)
+        response = addCookieHeaders(response, translationCursor)
+        response = addPreloadHeaders(response, request, translationCursor)
 
         return response
     }
@@ -65,9 +78,63 @@ export const addCacheHeader = (response: CloudFrontResponse) => {
 export const addRobotsHeader = (response: CloudFrontResponse, config: Config) => {
     let headers = response.headers
 
-    if (config.blockRobots === 'true') {
+    if (config.environment === 'staging') {
         headers = setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow')
     }
 
     return {...response, headers}
+}
+
+/**
+ * Adds cookie HTTP header to the response to prevent indexing by bots (only in staging)
+ */
+export const addCookieHeaders = (response: CloudFrontResponse, translationCursor: string) => {
+    let headers = response.headers
+
+    headers = setHeader(headers, 'Set-Cookie', `translation-hash=${translationCursor}`)
+
+    return {...response, headers}
+}
+
+/**
+ * Adds cookie HTTP header to the response to prevent indexing by bots (only in staging)
+ */
+export const addPreloadHeaders = (
+    response: CloudFrontResponse,
+    request: CloudFrontRequest,
+    translationCursor: string
+) => {
+    let headers = response.headers
+    const urlParams = new URLSearchParams(request.querystring)
+    const language = urlParams.get('lang') || extractCookie(request.headers, 'x-pleo-language')
+    console.log('language', language)
+    headers = setHeader(
+        headers,
+        'Link',
+        ` </static/translations/${language}/messages.${translationCursor}.js>; rel="preload"; as="script"`
+    )
+
+    return {...response, headers}
+}
+
+const extractCookie = (headers: CloudFrontHeaders, cname: string) => {
+    const cookies = headers['cookie']
+    if (!cookies) {
+        console.log("extract_cookie(): no 'Cookie:' headers in request")
+        return null
+    }
+
+    for (let n = cookies.length; n--; ) {
+        const cval = cookies[n].value.split(/;\ /)
+        const vlen = cval.length
+
+        for (var m = vlen; m--; ) {
+            const cookie_kv = cval[m].split('=')
+            if (cookie_kv[0] === cname) {
+                return cookie_kv[1]
+            }
+        }
+    }
+
+    return null
 }

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -10,7 +10,8 @@ import {
     getHeader,
     TRANSLATION_CURSOR_HEADER,
     DEFAULT_TRANSLATION_CURSOR,
-    TREE_HASH_HEADER
+    TREE_HASH_HEADER,
+    getCookie
 } from '../utils'
 
 /**
@@ -35,7 +36,7 @@ export function getHandler(config: Config) {
         response = addSecurityHeaders(response, config)
         response = addCacheHeader(response)
         response = addRobotsHeader(response, config)
-        response = addCookieHeader(response, translationCursor)
+        response = setTranslationHashCookie(response, translationCursor)
         if (translationCursor !== DEFAULT_TRANSLATION_CURSOR) {
             response = addPreloadHeader(response, request, translationCursor, treeHash)
         }
@@ -96,7 +97,10 @@ export const addRobotsHeader = (response: CloudFrontResponse, config: Config) =>
 /**
  * Adds cookie 'translation-hash' with value of latest translation cursor
  */
-export const addCookieHeader = (response: CloudFrontResponse, translationCursor: string) => {
+export const setTranslationHashCookie = (
+    response: CloudFrontResponse,
+    translationCursor: string
+) => {
     let headers = response.headers
 
     headers = setHeader(headers, 'Set-Cookie', `translation-hash=${translationCursor}`)
@@ -131,32 +135,4 @@ export const addPreloadHeader = (
     )
 
     return {...response, headers}
-}
-
-/**
- * Extract the value of a specific cookie from CloudFront headers map, if present
- * @param headers - CloudFront headers map
- * @param cookieName - The key of the cookie to extract the value for
- * @returns The string value of the cookie if present, otherwise null
- */
-export function getCookie(headers: CloudFrontHeaders, cookieName: string) {
-    const cookieHeader = headers.cookie
-
-    if (!cookieHeader) {
-        return null
-    }
-
-    for (const cookieSet of cookieHeader) {
-        const cookies = cookieSet.value.split(/; /)
-
-        for (const cookie of cookies) {
-            const cookieKeyValue = cookie.split('=')
-
-            if (cookieKeyValue[0] === cookieName) {
-                return cookieKeyValue[1]
-            }
-        }
-    }
-
-    return null
 }

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -27,16 +27,18 @@ export function getHandler(config: Config) {
         let response = event.Records[0].cf.response
         const request = event.Records[0].cf.request
 
-        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER)
-
-        const treeHash = getHeader(request, TREE_HASH_HEADER)
-
         response = addSecurityHeaders(response, config)
         response = addCacheHeader(response)
         response = addRobotsHeader(response, config)
-        response = setTranslationHashCookie(response, translationCursor)
-        if (Boolean(translationCursor)) {
-            response = addPreloadHeader(response, request, translationCursor, treeHash)
+
+        if (config.isLocalised === 'true') {
+            const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER)
+            const treeHash = getHeader(request, TREE_HASH_HEADER)
+
+            response = setTranslationHashCookie(response, translationCursor)
+            if (Boolean(translationCursor)) {
+                response = addPreloadHeader(response, request, translationCursor, treeHash)
+            }
         }
 
         return response

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -5,7 +5,7 @@ import {
     CloudFrontRequest
 } from 'aws-lambda'
 import {Config} from '../config'
-import {setHeader, getHeader, TRANSLATION_CURSOR_HEADER} from '../utils'
+import {setHeader, getHeader, TRANSLATION_CURSOR_HEADER, DEFAULT_TRANSLATION_CURSOR} from '../utils'
 
 /**
  * Edge Lambda handler triggered on "viewer-response" event, on the default CF behavior of the web app CF distribution.
@@ -21,13 +21,16 @@ export function getHandler(config: Config) {
         let response = event.Records[0].cf.response
         const request = event.Records[0].cf.request
 
-        const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER) || 'default'
+        const translationCursor =
+            getHeader(request, TRANSLATION_CURSOR_HEADER) || DEFAULT_TRANSLATION_CURSOR
 
         response = addSecurityHeaders(response, config)
         response = addCacheHeader(response)
         response = addRobotsHeader(response, config)
         response = addCookieHeader(response, translationCursor)
-        response = addPreloadHeader(response, request, translationCursor)
+        if (translationCursor !== DEFAULT_TRANSLATION_CURSOR) {
+            response = addPreloadHeader(response, request, translationCursor)
+        }
 
         return response
     }

--- a/edge-lambdas/src/viewer-response/viewer-response.ts
+++ b/edge-lambdas/src/viewer-response/viewer-response.ts
@@ -1,17 +1,7 @@
-import {
-    CloudFrontResponse,
-    CloudFrontResponseHandler,
-    CloudFrontHeaders,
-    CloudFrontRequest
-} from 'aws-lambda'
+import {CloudFrontResponse, CloudFrontResponseHandler} from 'aws-lambda'
 import {Config} from '../config'
-import {
-    setHeader,
-    getHeader,
-    TRANSLATION_CURSOR_HEADER,
-    TREE_HASH_HEADER,
-    getCookie
-} from '../utils'
+import {addTranslationInfoToResponse} from '../addons/translations'
+import {setHeader} from '../utils'
 
 /**
  * Edge Lambda handler triggered on "viewer-response" event, on the default CF behavior of the web app CF distribution.
@@ -30,16 +20,7 @@ export function getHandler(config: Config) {
         response = addSecurityHeaders(response, config)
         response = addCacheHeader(response)
         response = addRobotsHeader(response, config)
-
-        if (config.isLocalised === 'true') {
-            const translationCursor = getHeader(request, TRANSLATION_CURSOR_HEADER)
-            const treeHash = getHeader(request, TREE_HASH_HEADER)
-
-            response = setTranslationHashCookie(response, translationCursor)
-            if (Boolean(translationCursor)) {
-                response = addPreloadHeader(response, request, translationCursor, treeHash)
-            }
-        }
+        response = addTranslationInfoToResponse(response, request, config)
 
         return response
     }
@@ -90,49 +71,6 @@ export const addRobotsHeader = (response: CloudFrontResponse, config: Config) =>
     if (config.blockRobots === 'true') {
         headers = setHeader(headers, 'X-Robots-Tag', 'noindex, nofollow')
     }
-
-    return {...response, headers}
-}
-
-/**
- * Adds cookie 'translation-hash' with value of latest translation cursor
- */
-export const setTranslationHashCookie = (
-    response: CloudFrontResponse,
-    translationCursor: string
-) => {
-    let headers = response.headers
-
-    headers = setHeader(headers, 'Set-Cookie', `translation-hash=${translationCursor}`)
-
-    return {...response, headers}
-}
-
-/**
- * Adds preload header for translation file to speed up rendering of the app,
- * since translation file is the required for it.
- * We get the language from the 'x-pleo-language' cookie
- * which is in sync with the user language to preload translation file with the language of the app.
- * But it is possible to override user&app language with the 'lang' url param,
- * since this overriding won't be refltected in the cookie yet, we get the language from this param 'lang'
- * If both, url param & cookie are empty, it means that language is not chosen by any form, which means that the app will be in 'en'
- */
-export const addPreloadHeader = (
-    response: CloudFrontResponse,
-    request: CloudFrontRequest,
-    translationCursor: string,
-    treeHash: string
-) => {
-    let headers = response.headers
-    const urlParams = new URLSearchParams(request.querystring)
-    const language = urlParams.get('lang') || getCookie(request.headers, 'x-pleo-language') || 'en'
-    const hash = language === 'en' ? treeHash : translationCursor
-
-    headers = setHeader(
-        headers,
-        'Link',
-        `</static/translations/${language}/messages.${hash}.js>; rel="preload"; as="script"`
-    )
 
     return {...response, headers}
 }

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -76,6 +76,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
+| <a name="input_is_localised"></a> [is\_localise](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -76,10 +76,10 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
-| <a name="input_is_localised"></a> [is\_localise](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
+| <a name="input_is_localised"></a> [is\_localised](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com) | `string` | n/a | yes |
 | <a name="input_zone_domain"></a> [zone\_domain](#input\_zone\_domain) | The domain where the app lives (e.g. 'example.com' if the app lives at hello.example.com) | `string` | n/a | yes |
 

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -79,7 +79,7 @@ No resources.
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
-| <a name="input_is_localised"></a> [is\_localised](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
+| <a name="input_is_localised"></a> [is\_localised](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `false` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com) | `string` | n/a | yes |
 | <a name="input_zone_domain"></a> [zone\_domain](#input\_zone\_domain) | The domain where the app lives (e.g. 'example.com' if the app lives at hello.example.com) | `string` | n/a | yes |
 

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -24,6 +24,7 @@ module "lambdas" {
   role_arn                 = module.lambda_role.role_arn
   env                      = var.env
   block_iframes            = var.block_iframes
+  is_localised             = var.is_localised
   default_repo_branch_name = var.default_repo_branch_name
   bucket_name              = module.s3.bucket_name
   bucket_region            = module.s3.bucket_region

--- a/terraform-module/modules/frontend-spa-edge-lambda/README.md
+++ b/terraform-module/modules/frontend-spa-edge-lambda/README.md
@@ -15,6 +15,7 @@ module "lambda" {
   domain_name              = "hello.example.com"
   default_repo_branch_name = "master"
   block_iframes            = true
+  is_localised             = true
   role_arn                 = module.lambda_role.role_arn
   lambda_version           = var.lambdas_version
   bucket_name              = module.s3.bucket_name
@@ -69,6 +70,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
+| <a name="input_is_localised"></a> [is\_localise](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the S3 origin bucket | `string` | n/a | yes |
 | <a name="input_bucket_region"></a> [bucket\_region](#input\_bucket\_region) | AWS region where the origin bucket is located | `string` | `"eu-west-1"` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |

--- a/terraform-module/modules/frontend-spa-edge-lambda/README.md
+++ b/terraform-module/modules/frontend-spa-edge-lambda/README.md
@@ -70,13 +70,13 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
-| <a name="input_is_localised"></a> [is\_localise](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the S3 origin bucket | `string` | n/a | yes |
 | <a name="input_bucket_region"></a> [bucket\_region](#input\_bucket\_region) | AWS region where the origin bucket is located | `string` | `"eu-west-1"` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | App domain name | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
 | <a name="input_event_type"></a> [event\_type](#input\_event\_type) | Type of the Lambda@Edge (viewer-request, viewer-response, origin-request, origin-response) | `string` | n/a | yes |
+| <a name="input_is_localised"></a> [is\_localised](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `true` | no |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | ARN of the lambda execution role | `string` | n/a | yes |
 
 #### Outputs

--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -12,6 +12,7 @@ resource "local_file" "lambda_config" {
     "originBucketRegion"       = var.bucket_region
     "previewDeploymentPostfix" = var.env == "staging" ? ".${var.domain_name}" : ""
     "blockIframes"             = var.block_iframes == true ? "true" : "false"
+    "isLocalised"              = var.is_localised == true ? "true" : "false"
     "blockRobots"              = var.env == "staging" ? "true" : "false"
     "defaultBranchName"        = var.default_repo_branch_name
   })

--- a/terraform-module/modules/frontend-spa-edge-lambda/vars.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/vars.tf
@@ -19,6 +19,12 @@ variable "block_iframes" {
   type        = bool
 }
 
+variable "is_localised" {
+  description = "Should fetch translation hash and add cookie & preload header for translation files?"
+  default     = true
+  type        = bool
+}
+
 variable "event_type" {
   description = "Type of the Lambda@Edge (viewer-request, viewer-response, origin-request, origin-response)"
   type        = string

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -29,6 +29,12 @@ variable "block_iframes" {
   type        = bool
 }
 
+variable "is_localised" {
+  description = "Should fetch translation hash and add cookie & preload header for translation files?"
+  default     = true
+  type        = bool
+}
+
 variable "default_repo_branch_name" {
   description = "Name of the default branch of the project repo"
   default     = "master"

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -31,7 +31,7 @@ variable "block_iframes" {
 
 variable "is_localised" {
   description = "Should fetch translation hash and add cookie & preload header for translation files?"
-  default     = true
+  default     = false
   type        = bool
 }
 


### PR DESCRIPTION
Support separately deployed translations by fetching a secondary cursor file with the current translation version and enriching the HTML response with a translation version cookie and a preload header for translation catalog.